### PR TITLE
feat: parse also `/config` path 

### DIFF
--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -41,7 +41,7 @@ class GettextShell extends Shell
                 'options' => [
                     'app' => [
                         'help' => 'The app path, for i18n update.',
-                        'short' => 'f',
+                        'short' => 'a',
                         'required' => false,
                     ],
                     'plugin' => [


### PR DESCRIPTION
In this PR:

* also `/config` folder is parsed for pot/po extraction, in addition to `/src`
* minor methods refactor introduced  
* `frontend` option changed to `app`
