### PR TITLE
Fix translations array + reset

### DIFF
--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -199,7 +199,8 @@ class I18nHelper extends Helper
                 $translations,
                 'translations.{n}.lang',
                 'translations.{n}.translated_fields',
-                'translations.{n}.object_id');
+                'translations.{n}.object_id'
+            );
         }
 
         $path = sprintf('%s.%s.%s', $id, $lang, $attribute);

--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -24,8 +24,10 @@ use Cake\View\Helper;
 class I18nHelper extends Helper
 {
     /**
-     * Translation data per object and lang internal cache.
-     * If `null` no cache has been created, if `[]` no translations have been found.
+     * Translation data per object and lang (internal cache).
+     * If `null` no cache has been created, if empty array no translations
+     * have been found.
+     *
      * Structure:
      *
      *   translation[<object ID>][<lang>][<field>] = <value>.

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -67,7 +67,6 @@ class I18nHelperTest extends TestCase
         ],
     ];
 
-
     /**
      * {@inheritDoc}
      */
@@ -91,7 +90,6 @@ class I18nHelperTest extends TestCase
             // usually set by middleware
             'lang' => 'en',
         ]);
-
     }
 
     /**

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -35,6 +35,40 @@ class I18nHelperTest extends TestCase
     protected $I18n = null;
 
     /**
+     * Test `object`
+     *
+     * @var array
+     */
+    protected $object = [
+        'id' => 999,
+        'attributes' => [
+            'title' => 'Sample',
+            'description' => 'A dummy example',
+            'lang' => 'en',
+        ],
+    ];
+
+    /**
+     * Test `included`
+     *
+     * @var array
+     */
+    protected $included = [
+        [
+            'id' => 99999,
+            'type' => 'translations',
+            'attributes' => [
+                'object_id' => 999,
+                'lang' => 'it',
+                'translated_fields' => [
+                    'title' => 'Esempio',
+                ],
+            ],
+        ],
+    ];
+
+
+    /**
      * {@inheritDoc}
      */
     public function setUp() : void
@@ -57,6 +91,7 @@ class I18nHelperTest extends TestCase
             // usually set by middleware
             'lang' => 'en',
         ]);
+
     }
 
     /**
@@ -156,33 +191,10 @@ class I18nHelperTest extends TestCase
      */
     public function fieldProvider() : array
     {
-        $objectBase = [
-            'id' => 999,
-            'title' => 'Sample',
-            'description' => 'A dummy example',
-            'lang' => 'en',
-        ];
-        $objectStructured = [
-            'id' => 999,
-            'attributes' => [
-                'title' => 'Sample',
-                'description' => 'A dummy example',
-                'lang' => 'en',
-            ],
-        ];
-        $included = [
-            [
-                'id' => 99999,
-                'type' => 'translations',
-                'attributes' => [
-                    'object_id' => 999,
-                    'lang' => 'it',
-                    'translated_fields' => [
-                        'title' => 'Esempio',
-                    ],
-                ],
-            ],
-        ];
+        $objectBase = ['id' => $this->object['id']] + $this->object['attributes'];
+        $objectStructured = $this->object;
+
+        $included = $this->included;
 
         return [
             'empty object' => [
@@ -255,27 +267,8 @@ class I18nHelperTest extends TestCase
      */
     public function existsProvider() : array
     {
-        $object = [
-            'id' => 999,
-            'attributes' => [
-                'title' => 'Sample',
-                'description' => 'A dummy example',
-                'lang' => 'en',
-            ],
-        ];
-        $included = [
-            [
-                'id' => 99999,
-                'type' => 'translations',
-                'attributes' => [
-                    'object_id' => 999,
-                    'lang' => 'it',
-                    'translated_fields' => [
-                        'title' => 'Esempio',
-                    ],
-                ],
-            ],
-        ];
+        $object = $this->object;
+        $included = $this->included;
 
         return [
             'empty object' => [
@@ -330,5 +323,62 @@ class I18nHelperTest extends TestCase
         }
         $actual = $this->I18n->exists($object, $attribute, $lang, $included);
         static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `exists()` method
+     *
+     * @covers ::exists()
+     * @covers ::getTranslatedField()
+     *
+     * @return void
+     */
+    public function testDefaultExists() : void
+    {
+        Configure::write('I18n.lang', 'it');
+
+        $actual = $this->I18n->exists($this->object, 'title');
+        static::assertFalse($actual);
+    }
+
+    /**
+     * Test internal translation cache
+     *
+     * @covers ::field()
+     * @covers ::getTranslatedField()
+     *
+     * @return void
+     */
+    public function testCache() : void
+    {
+        Configure::write('I18n.lang', 'it');
+
+        $actual = $this->I18n->field($this->object, 'title', null, false, $this->included);
+        static::assertEquals('Esempio', $actual);
+
+        // use cache
+        $actual = $this->I18n->field($this->object, 'title');
+        static::assertEquals('Esempio', $actual);
+    }
+
+    /**
+     * Test `reset()` method
+     *
+     * @covers ::reset()
+     * @covers ::getTranslatedField()
+     *
+     * @return void
+     */
+    public function testCacheReset() : void
+    {
+        Configure::write('I18n.lang', 'it');
+
+        $actual = $this->I18n->field($this->object, 'title', null, false, $this->included);
+        static::assertEquals('Esempio', $actual);
+
+        // reset cache
+        $this->I18n->reset();
+        $actual = $this->I18n->field($this->object, 'title');
+        static::assertEquals('Sample', $actual);
     }
 }


### PR DESCRIPTION
Internal translation array structure was fixed.
New `reset()` method to reset internal translation array.
 