### PR TITLE
Feat: add i18n route class

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,55 @@ $middlewareQueue->add(new I18nMiddleware([
 ]));
 ```
 
+### I18nRoute
+
+`I18nRoute` class can be used to simplify the way you write and match routing rules. For example writing
+
+```php
+$routes->connect(
+    '/pages',
+    [
+        'controller' => 'Pages',
+        'action' => 'index',
+    ],
+    [
+        '_name' => 'pages:index',
+        'routeClass' => 'BEdita/I18n.I18nRoute',
+    ]
+);
+```
+
+maps to `/:lang/pages` and the language code defined in `I18n.languages` configuration will be used as route patterns on `:lang` param.
+
+So the above rule is the same of
+
+```php
+$routes->connect(
+    '/:lang/pages',
+    [
+        'controller' => 'Pages',
+        'action' => 'index',
+    ],
+    ['_name' => 'pages:index']
+)
+->setPatterns(['lang' => 'it|en']);
+```
+
+If the current language is `it` you can obtain the localized url as
+
+```php
+// default
+$url = \Cake\Routing\Router::url(['_name' => 'pages:index']);
+echo $url; // prints /it/pages
+
+// get url with another supported lang
+$url = \Cake\Routing\Router::url([
+    '_name' => 'pages:index',
+    'lang' => 'en',
+]);
+echo $url; // prints /en/pages
+```
+
 ### I18nHelper
 
 In order to use the helper you need to initialize it in your `AppView::initialize()` method

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ $middlewareQueue->add(new I18nMiddleware([
 
 ### I18nRoute
 
-`I18nRoute` class can be used to simplify the way you write and match routing rules. For example writing
+`I18nRoute` class can be used to simplify the way you write and match routing rules.
+For example
 
 ```php
 $routes->connect(

--- a/src/Routing/Route/I18nRoute.php
+++ b/src/Routing/Route/I18nRoute.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\I18n\Routing\Route;
+
+use BEdita\I18n\Core\I18nTrait;
+use Cake\Core\Configure;
+use Cake\Routing\Route\Route;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * I18n Route class.
+ *
+ * It helps to build and match I18n routing rules.
+ */
+class I18nRoute extends Route
+{
+    use I18nTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($template, $defaults = [], array $options = [])
+    {
+        parent::__construct($this->buildTemplate($template), $defaults, $options);
+
+        if (empty($options['lang'])) {
+            $this->setPatterns(['lang' => implode('|', array_keys($this->getLanguages()))]);
+        }
+    }
+
+    /**
+     * Build the right route template adding :lang if needed.
+     *
+     * If :lang is not found add it at the beginning, for example /simple/path becomes /:lang/simple/path
+     *
+     * @param string $template The initial template.
+     * @return string
+     */
+    protected function buildTemplate(string $template) : string
+    {
+        if ($template === '/') {
+            return '/:lang';
+        }
+
+        if (preg_match('/\/:lang(\/.*|$)/', $template)) {
+            return $template;
+        }
+
+        return $template = '/:lang' . $template;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function match(array $url, array $context = [])
+    {
+        if (!array_key_exists('lang', $url)) {
+            $url['lang'] = $this->getLang();
+        }
+
+        return parent::match($url, $context);
+    }
+}

--- a/tests/TestCase/Routing/Route/I18nRouteTest.php
+++ b/tests/TestCase/Routing/Route/I18nRouteTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\I18n\Test\Routing\Route;
+
+use BEdita\I18n\Core\I18nTrait;
+use BEdita\I18n\Routing\Route\I18nRoute;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\I18n\Routing\Route\I18nRoute} Test Case
+ *
+ * @coversDefaultClass \BEdita\I18n\Routing\Route\I18nRoute
+ */
+class I18nRouteTest extends TestCase
+{
+    use I18nTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        Configure::write('I18n', [
+            'locales' => [
+                'en_US' => 'en',
+                'it_IT' => 'it',
+            ],
+            'default' => 'en',
+            'languages' => [
+                'en' => 'English',
+                'it' => 'Italiano',
+            ],
+
+            // usually set by middleware
+            'lang' => 'it',
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown() : void
+    {
+        parent::tearDown();
+
+        Configure::delete('I18n');
+    }
+
+    /**
+     * Data provider for testBuildTemplate
+     *
+     * @return array
+     */
+    public function templateProvider() : array
+    {
+        return [
+            'root' => [
+                '/:lang',
+                '/',
+            ],
+            'rootLang' => [
+                '/:lang',
+                '/:lang',
+            ],
+            'simplePath' => [
+                '/:lang/simple/path',
+                '/simple/path',
+            ],
+            'simplePath2' => [
+                '/:lang/:controller/:action',
+                '/:controller/:action',
+            ],
+            'pathStartsWithLang' => [
+                '/:lang/path/here',
+                '/:lang/path/here',
+            ],
+            'pathContainLangLike' => [
+                '/:lang/:language/path/here',
+                '/:language/path/here',
+            ],
+            'pathWithLangInside' => [
+                '/:controller/:lang/other',
+                '/:controller/:lang/other',
+            ],
+        ];
+    }
+
+    /**
+     * Test buildTemplate method
+     *
+     * @param string $expected The expected template for the route
+     * @param string $template The initial template
+     * @return void
+     *
+     * @dataProvider templateProvider
+     * @covers ::__construct()
+     * @covers ::buildTemplate()
+     */
+    public function testBuildTemplate(string $expected, string $template) : void
+    {
+        $route = new I18nRoute($template);
+        static::assertEquals($expected, $route->template);
+    }
+
+    /**
+     * Data provider for testLangPatterns
+     *
+     * @return array
+     */
+    public function langPatternsProvider() : array
+    {
+        return [
+            'noOptions' => [
+                'en|it',
+                [],
+            ],
+            'langPatterns' => [
+                'sp|fr',
+                [
+                    'lang' => 'sp|fr',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test that `lang` pattern is rightly set.
+     *
+     * @param string $expected The expected pattern for 'lang'
+     * @param array $options The options for constructor.
+     * @return void
+     *
+     * @dataProvider langPatternsProvider
+     * @covers ::__construct()
+     */
+    public function testLangPatterns(string $expected, array $options) : void
+    {
+        $route = new I18nRoute('/', [], $options);
+        static::assertEquals($expected, $route->options['lang']);
+    }
+
+    /**
+     * Test that if missing 'lang' param match() method return current lang in path.
+     *
+     * @return void
+     *
+     * @covers ::match()
+     */
+    public function testMatchUseCurrentLang() : void
+    {
+        $route = new I18nRoute(
+            '/gustavo/help',
+            ['controller' => 'GustavoSupporto', 'action' => 'help']
+        );
+
+        $result = $route->match([
+            'controller' => 'GustavoSupporto',
+            'action' => 'help',
+        ]);
+
+        $this->assertEquals(sprintf('/%s/gustavo/help', $this->getLang()), $result);
+    }
+
+    /**
+     * Test that passing a different lang match() method return it in path
+     *
+     * @return void
+     *
+     * @covers ::match()
+     */
+    public function testMatchUseCustomLang() : void
+    {
+        $route = new I18nRoute(
+            '/gustavo/help',
+            ['controller' => 'GustavoSupporto', 'action' => 'help']
+        );
+
+        $result = $route->match([
+            'controller' => 'GustavoSupporto',
+            'action' => 'help',
+            'lang' => 'en',
+        ]);
+
+        $this->assertEquals('/en/gustavo/help', $result);
+        $this->assertNotEquals('en', $this->getLang());
+    }
+
+    /**
+     * Test that passing an invalid lang match() method return false
+     *
+     * @return void
+     *
+     * @covers ::match()
+     */
+    public function testMatchInvalidLang() : void
+    {
+        $route = new I18nRoute(
+            '/gustavo/help',
+            ['controller' => 'GustavoSupporto', 'action' => 'help']
+        );
+
+        $result = $route->match([
+            'controller' => 'GustavoSupporto',
+            'action' => 'help',
+            'lang' => 'sp',
+        ]);
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
After this PR it is possible to write route rules as

```php
$routes->connect(
    '/pages',
    [
        'controller' => 'Pages',
        'action' => 'index',
    ],
    [
        '_name' => 'pages:index',
        'routeClass' => 'BEdita/I18n.I18nRoute',
    ]
);
```

`\BEdita\I18n\Routing\Route\I18nRoute` will take care of creating the route rule `/:lang/pages` setting the `lang` patterns too for `lang` param validation.

It also helps to build I18n URL:

```php
// use current lang
$url = \Cake\Routing\Router::url(['_name' => 'pages:index']);
echo $url; // prints /it/pages if 'it' was the current lang

// get url with another supported lang
$url = \Cake\Routing\Router::url([
    '_name' => 'pages:index',
    'lang' => 'en',
]);
echo $url; // prints /en/pages
```