### PR TITLE
Add hreflang meta generation

### DIFF
--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -21,10 +21,17 @@ use Cake\View\Helper;
 
 /**
  * Helper to handle i18n things in view.
+ *
+ * @property \Cake\View\Helper\HtmlHelper $Html The HtmlHelper
  */
 class I18nHelper extends Helper
 {
     use I18nTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public $helpers = ['Html'];
 
     /**
      * Translation data per object and lang (internal cache).
@@ -82,17 +89,62 @@ class I18nHelper extends Helper
      */
     protected function newLangUrl($newLang, $path, $query) : ?string
     {
-        $prefix = sprintf('/%s', $this->getLang());
-        if (stripos($path, $prefix . '/') === 0 || $path === $prefix) {
-            $url = sprintf('/%s', $newLang) . substr($path, strlen($prefix));
-            if ($query) {
-                $url .= '?' . $query;
-            }
-
-            return $url;
+        if (!$this->isI18nPath($path)) {
+            return null;
         }
 
-        return null;
+        $prefix = sprintf('/%s', $this->getLang());
+        $url = sprintf('/%s', $newLang) . substr($path, strlen($prefix));
+        if ($query) {
+            $url .= '?' . $query;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Return true if an URL path has I18n structure i.e. /:lang/other/path or /:lang
+     *
+     * @param string $path The path to check.
+     * @return bool
+     */
+    protected function isI18nPath(string $path) : bool
+    {
+        $prefix = sprintf('/%s', $this->getLang());
+
+        return stripos($path, $prefix . '/') === 0 || $path === $prefix;
+    }
+
+    /**
+     * Create a hreflang meta tag for available languages.
+     * The meta will be created only if a recognizable i18n path was found on current URL.
+     *
+     * @return string
+     */
+    public function metaHreflang() : string
+    {
+        $request = Router::getRequest();
+        if ($request === null) {
+            return '';
+        }
+
+        $path = $request->getUri()->getPath();
+        if (!$this->isI18nPath($path)) {
+            return '';
+        }
+
+        $query = $request->getUri()->getQuery();
+        $meta = '';
+        foreach (array_keys($this->getLanguages()) as $code) {
+            $url = Router::url($this->newLangUrl($code, $path, $query), true);
+            $meta .= $this->Html->meta([
+                'rel' => 'alternate',
+                'hreflang' => $code,
+                'link' => $url,
+            ]);
+        }
+
+        return $meta;
     }
 
     /**

--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -116,7 +116,7 @@ class I18nHelper extends Helper
     }
 
     /**
-     * Create a hreflang meta tag for available languages.
+     * Create hreflang meta tags for available languages.
      * The meta will be created only if a recognizable i18n path was found on current URL.
      *
      * @return string

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -425,7 +425,7 @@ class I18nHelperTest extends TestCase
     }
 
     /**
-     * Test that `metaHreflang()` return an empty string if no request was set.
+     * Test that `metaHreflang()` returns an empty string if no request was set.
      *
      * @return void
      *

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -118,6 +118,14 @@ class I18nHelperTest extends TestCase
                 ],
                 'en',
             ],
+            'noChangeWithQueryString' => [
+                '/help?page=1',
+                [
+                    'REQUEST_URI' => '/help',
+                    'QUERY_STRING' => 'page=1',
+                ],
+                'en',
+            ],
             'change' => [
                 '/it/help',
                 [
@@ -161,6 +169,8 @@ class I18nHelperTest extends TestCase
      *
      * @dataProvider changeUrlLangProvider
      * @covers ::changeUrlLang()
+     * @covers ::newLangUrl()
+     * @covers ::isI18nPath()
      */
     public function testChangeUrlLang($expected, array $server, $lang, $switchUrl = null) : void
     {

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -369,4 +369,60 @@ class I18nHelperTest extends TestCase
         $actual = $this->I18n->field($this->object, 'title');
         static::assertEquals('Sample', $actual);
     }
+
+    /**
+     * Data provider for `testMetaHreflang()`
+     *
+     * @return array
+     */
+    public function metaHreflangProvider() : array
+    {
+        return [
+            'empty' => [
+                '',
+                [
+                    'REQUEST_URI' => '/help',
+                ],
+            ],
+            'meta' => [
+                '<link href="http://localhost/en/help" rel="alternate" hreflang="en"/><link href="http://localhost/it/help" rel="alternate" hreflang="it"/>',
+                [
+                    'REQUEST_URI' => '/en/help',
+                    'PHP_SELF' => '/',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test meta tag hreflang.
+     *
+     * @param string $expected The expected output.
+     * @param array $server Request configuration.
+     * @return void
+     *
+     * @dataProvider metaHreflangProvider
+     * @covers ::metaHreflang()
+     */
+    public function testMetaHreflang($expected, $server) : void
+    {
+        $request = ServerRequestFactory::fromGlobals($server);
+        Router::$initialized = true; // avoid trying to load rules from routes.php
+        Router::pushRequest($request);
+
+        $meta = $this->I18n->metaHreflang();
+        static::assertEquals($expected, $meta);
+    }
+
+    /**
+     * Test that `metaHreflang()` return an empty string if no request was set.
+     *
+     * @return void
+     *
+     * @covers ::metaHreflang()
+     */
+    public function testMetaHreflangMissingRequest() : void
+    {
+        static::assertEquals('', $this->I18n->metaHreflang());
+    }
 }


### PR DESCRIPTION
This PR add the ability to generate `hreflang` meta tag for i18n pages.

To use it in view:

```php
echo $this->I18n->metaHreflang();
```

For  example the generated HTML for an URL as `https://example.com/en/help` will be

```html
<link href="http://localhost/en/help" rel="alternate" hreflang="en"/>
<link href="http://localhost/it/help" rel="alternate" hreflang="it"/>
```

for `I18n.languages` configuration

```php
Configure::write('I18n', [
    // other I18n stuff
    // ....
    'languages' => [
        'en' => 'English',
        'it' => 'Italiano',
    ],
    // other I18n stuff
    // ....
]);
```