### PR TITLE
Middleware disabled by default

### DIFF
--- a/src/Middleware/I18nMiddleware.php
+++ b/src/Middleware/I18nMiddleware.php
@@ -19,6 +19,7 @@ use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\I18n;
@@ -174,6 +175,12 @@ class I18nMiddleware implements MiddlewareInterface
         if ($lang === null) {
             $lang = $this->getDefaultLang();
             $locale = array_search($lang, $locales);
+        }
+
+        if ($lang === null || $locale === false) {
+            throw new InternalErrorException(
+                __('Something was wrong with I18n configuration. Check "I18n.locales" and "I18n.default"')
+            );
         }
 
         Configure::write('I18n.lang', $lang);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -40,6 +40,13 @@ class Plugin extends BasePlugin
     protected $routesEnabled = false;
 
     /**
+     * Enable middleware
+     *
+     * @var bool
+     */
+    protected $middlewareEnabled = false;
+
+    /**
      * Setup the I8nMiddleware.
      *
      * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.

--- a/tests/TestCase/Middleware/I18nMiddlewareTest.php
+++ b/tests/TestCase/Middleware/I18nMiddlewareTest.php
@@ -18,6 +18,7 @@ use BEdita\I18n\Middleware\I18nMiddleware;
 use Cake\Core\Configure;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\I18n\I18n;
@@ -334,6 +335,26 @@ class I18nMiddlewareTest extends TestCase
 
         static::assertEquals($expected['locale'], I18n::getLocale());
         static::assertEquals($expected['lang'], Configure::read('I18n.lang'));
+    }
+
+    /**
+     * Test that an exception is raised if missing required conf.
+     *
+     * @return void
+     *
+     * @covers ::setupLocale()
+     */
+    public function testSetupLocaleMissingConfig(): void
+    {
+        $this->expectException(InternalErrorException::class);
+        $this->expectExceptionCode(500);
+
+        Configure::delete('I18n');
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/help',
+        ]);
+        $middleware = new I18nMiddleware();
+        $middleware->process($request, $this->requestHandler);
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -70,4 +70,4 @@ if (!getenv('db_dsn')) {
 ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
 Router::reload();
 
-Plugin::getCollection()->add(new \BEdita\I18n\Plugin());
+Plugin::getCollection()->add(new \BEdita\I18n\Plugin(['middleware' => true]));


### PR DESCRIPTION
To avoid unexpected behavior the `I18nMiddleware` is disabled by default.

Moreover an exception is thrown when some basic locale configuration is missing.