### PR TITLE
Extend backward support up to CakePHP 3.8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     paths:
       - '**/*.php'
+      - '.github/workflows/*'
   push:
     paths:
       - '**/*.php'
+      - '.github/workflows/*'
 
 jobs:
   cs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,10 +14,6 @@ jobs:
     if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
     runs-on: 'ubuntu-18.04'
 
-    strategy:
-      matrix:
-        php-version: [7.2]
-
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
@@ -25,8 +21,8 @@ jobs:
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
         with:
-          php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v1'
+          php-version: '7.4'
+          tools: 'composer:v2'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -58,10 +54,6 @@ jobs:
     runs-on: 'ubuntu-18.04'
     continue-on-error: true
 
-    strategy:
-      matrix:
-        php-version: [7.2, 7.3, 7.4]
-
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
@@ -69,8 +61,8 @@ jobs:
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
         with:
-          php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v1, phpstan'
+          php-version: '7.4'
+          tools: 'composer:v2, phpstan'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -117,7 +109,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v1'
+          tools: 'composer:v2'
           extensions: 'mbstring, intl'
 
       - name: 'Discover Composer cache directory'
@@ -157,3 +149,38 @@ jobs:
         with:
           name: 'PHP ${{ matrix.php }}'
           path: 'clover.xml'
+
+  unit-lowest:
+    name: 'Run unit tests with lowest-matching dependencies versions'
+    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
+    runs-on: 'ubuntu-18.04'
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '7.2'
+          tools: 'composer:v1'
+          extensions: 'mbstring, intl, pdo_sqlite'
+
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: "composer-lowest-${{ hashFiles('**/composer.json') }}"
+          restore-keys: |
+            composer-lowest-
+            composer-
+
+      - name: 'Install dependencies with Composer'
+        run: 'composer update --prefer-lowest --prefer-dist --no-interaction'
+
+      - name: 'Run PHPUnit'
+        run: 'vendor/bin/phpunit'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -101,8 +101,8 @@ jobs:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
 
-      - name: Install GNU gettext
-        run: sudo apt-get install -y gettext
+      - name: 'Install GNU gettext'
+        run: 'sudo apt-get install -y gettext'
 
       - name: 'Composer config GH token if available'
         run: 'if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi'
@@ -160,6 +160,12 @@ jobs:
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
+
+      - name: 'Install GNU gettext'
+        run: 'sudo apt-get install -y gettext'
+
+      - name: 'Composer config GH token if available'
+        run: 'if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi'
 
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "laminas/laminas-diactoros": "^1.4.0|^2.2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6|^7",
+        "phpunit/phpunit": "^6|^7|^8",
         "psr/http-server-middleware": "^1.0",
         "cakephp/cakephp-codesniffer": "~4.2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "~3.8.3|~4.2.2",
+        "cakephp/cakephp": "^3.8.3|~4.2.2",
         "laminas/laminas-diactoros": "^1.4.0|^2.2.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         }
     },
     "scripts": {
-        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump",
         "check": [
             "@test",
             "@cs-check"

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,12 @@
     },
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "~4.2.2"
+        "cakephp/cakephp": "~3.8.3|~4.2.2",
+        "laminas/laminas-diactoros": "^1.4.0|^2.2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^6|^7",
+        "psr/http-server-middleware": "^1.0",
         "cakephp/cakephp-codesniffer": "~4.2.0"
     },
     "autoload": {

--- a/src/Middleware/I18nMiddleware.php
+++ b/src/Middleware/I18nMiddleware.php
@@ -231,7 +231,7 @@ class I18nMiddleware implements MiddlewareInterface
         }
 
         $response = (new Response())
-            ->withLocation((string)$request->referer())
+            ->withLocation((string)$request->referer(false))
             ->withDisabledCache()
             ->withStatus(302);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,7 +52,7 @@ class Plugin extends BasePlugin
      * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
      * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
      */
-    public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+    public function middleware($middlewareQueue): MiddlewareQueue
     {
         $middlewareQueue = parent::middleware($middlewareQueue);
 

--- a/src/Routing/Route/I18nRoute.php
+++ b/src/Routing/Route/I18nRoute.php
@@ -68,6 +68,6 @@ class I18nRoute extends Route
             $url['lang'] = $this->getLang();
         }
 
-        return parent::match($url, $context);
+        return parent::match($url, $context) ?: null;
     }
 }

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -298,7 +298,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     {
         $method = self::getMethod('parseDir');
         $method->invokeArgs($this->shell, [ $dir ]);
-        static::assertEquals($expected, $this->shell->poResult);
+        static::assertEquals($expected, $this->shell->poResult, '', 0, 10, true);
     }
 
     /**

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -182,7 +182,8 @@ class I18nHelperTest extends TestCase
     {
         if (!empty($server)) {
             $request = ServerRequestFactory::fromGlobals($server);
-            Router::setRequest($request);
+            $method = method_exists(Router::class, 'setRequest') ? 'setRequest' : 'pushRequest';
+            Router::$method($request);
         }
 
         static::assertEquals($expected, $this->I18n->changeUrlLang($lang, $switchUrl));
@@ -417,7 +418,8 @@ class I18nHelperTest extends TestCase
     public function testMetaHreflang($expected, $server): void
     {
         $request = ServerRequestFactory::fromGlobals($server);
-        Router::setRequest($request);
+        $method = method_exists(Router::class, 'setRequest') ? 'setRequest' : 'pushRequest';
+        Router::$method($request);
 
         $meta = $this->I18n->metaHreflang();
         static::assertEquals($expected, $meta);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -69,5 +69,6 @@ if (!getenv('db_dsn')) {
 }
 ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
 Router::reload();
+Router::fullBaseUrl('http://localhost');
 
 Plugin::getCollection()->add(new \BEdita\I18n\Plugin(['middleware' => true]));

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -18,7 +18,7 @@ class Application extends BaseApplication
     /**
      * @inheritDoc
      */
-    public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+    public function middleware($middlewareQueue): MiddlewareQueue
     {
         $middlewareQueue->add(new RoutingMiddleware($this));
 


### PR DESCRIPTION
This PR extends support up to CakePHP 3.8. This may be useful for applications that choose to use a CakePHP version in the 3.x series.

As you can see, changes in the sources are minimal: one type-check removed to comply with parent method's signatures in both versions, one `?: null` added when returning to turn a `false` into a `null`, and one parameter explicitly set to ensure consistent behaviour across versions where the default one changes.
Relevant dependency changes are in the `require` part only: `cakephp/cakephp` is now required as `~3.8.3|^4.2.2`, although probably a `>= 3.8.3 < 5` constraint would suffice, and a dependency from `laminas/laminas-diactoros` has been explicitly added.

The dependency from `laminas/laminas-diactoros` [is already present](https://github.com/bedita/i18n/blob/ca55d57/src/Middleware/I18nMiddleware.php#L28), but since CakePHP 4 already requires the library on its own, our code works. Regardless of the scopes of this PR, such dependency should be added to our `composer.json` anyway. Its constraints are such that both CakePHP 3.x and 4.x are happy.

Tests had to be changed a bit more to allow for different signatures and in some cases completely different methods… but they are tests, so as long as they check what we're interested in, it's fine.

In the workflow, Composer 2 is used, and unit tests are run against lowest-matching dependencies as well.