### PR TITLE
Embedded translations

### DIFF
--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -239,6 +239,16 @@ class I18nHelper extends Helper
      */
     private function getTranslatedField(array $object, string $attribute, string $lang, array &$included): ?string
     {
+        // first look if embedded relationships are set
+        if (!empty($object['relationships']['translations']['data'][0]['attributes'])) {
+            $translations = Hash::combine(
+                $object['relationships']['translations']['data'],
+                '{n}.attributes.lang',
+                '{n}.attributes.translated_fields',
+            );
+            return Hash::get($translations, sprintf('%s.%s', $lang, $attribute));
+        }
+
         if (empty($object['id'])) {
             return null;
         }

--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -240,7 +240,7 @@ class I18nHelper extends Helper
     private function getTranslatedField(array $object, string $attribute, string $lang, array &$included): ?string
     {
         // first look if embedded relationships are set
-        if (!empty($object['relationships']['translations']['data'][0]['attributes'])) {
+        if (Hash::check($object, 'relationships.translations.data.0.attributes')) {
             $translations = Hash::combine(
                 $object['relationships']['translations']['data'],
                 '{n}.attributes.lang',

--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -246,6 +246,7 @@ class I18nHelper extends Helper
                 '{n}.attributes.lang',
                 '{n}.attributes.translated_fields',
             );
+
             return Hash::get($translations, sprintf('%s.%s', $lang, $attribute));
         }
 

--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -244,7 +244,7 @@ class I18nHelper extends Helper
             $translations = Hash::combine(
                 $object['relationships']['translations']['data'],
                 '{n}.attributes.lang',
-                '{n}.attributes.translated_fields',
+                '{n}.attributes.translated_fields'
             );
 
             return Hash::get($translations, sprintf('%s.%s', $lang, $attribute));

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -300,7 +300,7 @@ class I18nHelperTest extends TestCase
         // 'fr' is not found, fallback to original
         $actual = $this->I18n->field($object, 'description', 'fr');
         static::assertEquals('una descrizione', $actual);
-   }
+    }
 
     /**
      * Data provider for `testExists()`

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -270,6 +270,7 @@ class I18nHelperTest extends TestCase
      *
      * @return void
      * @covers ::field()
+     * @covers ::getTranslatedField()
      */
     public function testFieldEmbedded(): void
     {

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -266,6 +266,43 @@ class I18nHelperTest extends TestCase
     }
 
     /**
+     * Test `field` method with embedded relationships
+     *
+     * @return void
+     * @covers ::field()
+     */
+    public function testFieldEmbedded(): void
+    {
+        $object = [
+            'attributes' => [
+                'description' => 'una descrizione',
+                'lang' => 'it',
+            ],
+            'relationships' => [
+                'translations' => [
+                    'data' => [
+                        [
+                            'attributes' => [
+                                'lang' => 'en',
+                                'status' => 'on',
+                                'translated_fields' => [
+                                    'description' => 'a description',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actual = $this->I18n->field($object, 'description', 'en');
+        static::assertEquals('a description', $actual);
+        // 'fr' is not found, fallback to original
+        $actual = $this->I18n->field($object, 'description', 'fr');
+        static::assertEquals('una descrizione', $actual);
+   }
+
+    /**
      * Data provider for `testExists()`
      *
      * @return array


### PR DESCRIPTION
Use embedded translations in `relationships.translations.data` array if set in `I18n.field()` helper method.

