### PR TITLE
gettext update parse all cakephp translation functions [master, 3.x]

### DIFF
--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -30,6 +30,7 @@ class GettextShell extends Shell
      * Get the option parser for this shell.
      *
      * @return \Cake\Console\ConsoleOptionParser
+     * @codeCoverageIgnore
      */
     public function getOptionParser(): ConsoleOptionParser
     {
@@ -297,36 +298,61 @@ class GettextShell extends Shell
      */
     private function parseFile($file, $extension)
     {
+        if (!in_array($extension, ['php', 'twig'])) {
+            return;
+        }
         $content = file_get_contents($file);
         if (empty($content)) {
             return;
         }
 
-        if ($extension === 'twig' || $extension === 'php') {
-            $this->parseContent($content);
+        $functions = [
+            '__' => 0, // __( string $singular , ... $args )
+            '__n' => 0, // __n( string $singular , string $plural , integer $count , ... $args )
+            '__d' => 1, // __d( string $domain , string $msg , ... $args )
+            '__dn' => 1, // __dn( string $domain , string $singular , string $plural , integer $count , ... $args )
+            '__x' => 1, // __x( string $context , string $singular , ... $args )
+            '__xn' => 1, // __xn( string $context , string $singular , string $plural , integer $count , ... $args )
+            '__dx' => 2, // __dx( string $domain , string $context , string $msg , ... $args )
+            '__dxn' => 2, // __dxn( string $domain , string $context , string $singular , string $plural , integer $count , ... $args )
+        ];
+
+        // temporarily replace "\'" with "|||||", fixString will replace "|||||" with "\'"
+        // this fixes wrongly matched data in the following regexp
+        $content = str_replace("\'", '|||||', $content);
+
+        $options = [
+            'open_parenthesis' => preg_quote('('),
+            'quote' => preg_quote("'"),
+            'double_quote' => preg_quote('"'),
+        ];
+
+        foreach ($functions as $fname => $singularPosition) {
+            if ($singularPosition === 0) {
+                $this->parseContent($fname, $content, $options);
+            } elseif ($singularPosition === 1) {
+                $this->parseContentSecondArg($fname, $content, $options);
+            } elseif ($singularPosition === 2) {
+                $this->parseContentThirdArg($fname, $content, $options);
+            }
         }
     }
 
     /**
      * Parse file content and put i18n data in poResult array
      *
+     * @param string $start The starting string to search for, the name of the translation method
      * @param string $content The file content
+     * @param array $options The options
      * @return void
      */
-    private function parseContent($content): void
+    private function parseContent($start, $content, $options): void
     {
-        $p = preg_quote('(');
-        $q1 = preg_quote("'");
-        $q2 = preg_quote('"');
-
-        // temporarily replace "\'" with "|||||", fixString will replace "|||||" with "\'"
-        // this fixes wrongly matched data in the following regexp
-        $content = str_replace("\'", '|||||', $content);
-
-        // looks for __("text to translate",true)
-        // or __('text to translate',true), result in matches[1] or in matches[2]
-        $rgxp = '/' . "__\s*{$p}\s*{$q2}" . "([^{$q2}]*)" . "{$q2}" .
-            '|' . "__\s*{$p}\s*{$q1}" . "([^{$q1}]*)" . "{$q1}" . '/';
+        $rgxp = "/" .
+            "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . "([^{$options['double_quote']}]*)" . "{$options['double_quote']}" .
+            "|" .
+            "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . "([^{$options['quote']}]*)" . "{$options['quote']}" .
+            "/";
         $matches = [];
         preg_match_all($rgxp, $content, $matches);
 
@@ -340,6 +366,92 @@ class GettextShell extends Shell
                 $this->poResult[] = $item;
             }
         }
+    }
+
+    /**
+     * Parse file content and put i18n data in poResult array
+     *
+     * @param string $start The starting string to search for, the name of the translation method
+     * @param string $content The file content
+     * @param array $options The options
+     * @return void
+     */
+    private function parseContentSecondArg($start, $content, $options): void
+    {
+        $rgxp =
+            "/" . "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . "([^{)}]*)" . "{$options['double_quote']}" .
+            "|" . "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . "([^{)}]*)" . "{$options['quote']}" .
+            "/";
+        $matches = [];
+        preg_match_all($rgxp, $content, $matches);
+
+        $limit = count($matches[0]);
+        for ($i = 0; $i < $limit; $i++) {
+            $str = $matches[2][$i];
+            if (substr_count($matches[2][0], ',') === 1) {
+                $str = substr(trim(substr($str, strpos($str, ',') + 1)), 1);
+            } elseif (substr_count($matches[2][0], ',') === 2) {
+                $str = trim(substr($str, strpos($str, ',') + 1));
+                $str = trim(substr($str, 0, strpos($str, ',')));
+                $str = substr($str, 1, -1);
+            }
+            $item = $this->fixString($str);
+            if (!in_array($item, $this->poResult)) {
+                $this->poResult[] = $item;
+            }
+        }
+    }
+
+    /**
+     * Parse file content and put i18n data in poResult array
+     *
+     * @param string $start The starting string to search for, the name of the translation method
+     * @param string $content The file content
+     * @param array $options The options
+     * @return void
+     */
+    private function parseContentThirdArg($start, $content, $options): void
+    {
+        $rgxp =
+            "/" . "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . "([^{)}]*)" . "{$options['double_quote']}" .
+            "|" . "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . "([^{)}]*)" . "{$options['quote']}" .
+            "/";
+        $matches = [];
+        preg_match_all($rgxp, $content, $matches);
+
+        $limit = count($matches[0]);
+        for ($i = 0; $i < $limit; $i++) {
+            $str = $matches[2][$i];
+            $pos = $this->strposX($str, ',', 2);
+            $str = trim(substr($str, $pos + 1));
+            if (strpos($str, ',') > 0) {
+                $str = substr($str, 1, strpos($str, ',') - 2);
+            } else {
+                $str = substr($str, 1);
+            }
+            $item = $this->fixString($str);
+            if (!in_array($item, $this->poResult)) {
+                $this->poResult[] = $item;
+            }
+        }
+    }
+
+    /**
+     * Calculate nth ($number) position of $needle in $haystack.
+     *
+     * @param string $haystack The haystack where to search
+     * @param string $needle The needle to search
+     * @param int $number The nth position to retrieve
+     * @return int|false
+     */
+    private function strposX($haystack, $needle, $number = 0)
+    {
+        return strpos(
+            $haystack,
+            $needle,
+            $number > 1 ?
+            $this->strposX($haystack, $needle, $number - 1) + strlen($needle) : 0
+        );
     }
 
     /**

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -34,7 +34,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     protected $shell = null;
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function setUp(): void
     {
@@ -51,7 +51,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function tearDown(): void
     {
@@ -62,9 +62,10 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     /**
      * Test update and private methods called inside update
      *
+     * @return void
      * @covers ::update()
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $this->shell->params['app'] = sprintf('%s/tests/files/gettext/app', getcwd());
 
@@ -89,7 +90,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      *
      * @return array
      */
-    public function setupPathsProvider()
+    public function setupPathsProvider(): array
     {
         $base = getcwd();
 
@@ -131,7 +132,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      * @dataProvider setupPathsProvider
      * @covers ::setupPaths()
      */
-    public function testSetupPaths($appPath, $startPath, $pluginName, array $expectedTemplatePaths, string $expectedLocalePath)
+    public function testSetupPaths($appPath, $startPath, $pluginName, array $expectedTemplatePaths, string $expectedLocalePath): void
     {
         $expectedPoName = 'default.po';
         if (!empty($appPath)) {
@@ -157,7 +158,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      * @covers ::writeMasterPot()
      * @return void
      */
-    public function testWriteMasterPot()
+    public function testWriteMasterPot(): void
     {
         // set localePath using reflection class
         $localePath = sprintf('%s/tests/files/gettext/app/resources/locales', getcwd());
@@ -167,14 +168,14 @@ class GettextShellTest extends ConsoleIntegrationTestCase
 
         // set poResult using reflection class
         $poResult = [
-            'This is a twig sample',
-            'A twig content',
-            'A twig string with \"double quotes\"',
-            "A twig string with \'single quotes\'",
             'This is a php sample',
             'A php content',
             'A php string with \"double quotes\"',
             "A php string with \'single quotes\'",
+            'This is a twig sample',
+            'A twig content',
+            'A twig string with \"double quotes\"',
+            "A twig string with \'single quotes\'",
         ];
         $reflection = new \ReflectionProperty(get_class($this->shell), 'poResult');
         $reflection->setAccessible(true);
@@ -199,7 +200,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      * @covers ::writePoFiles()
      * @covers ::analyzePoFile()
      */
-    public function testWritePoFiles()
+    public function testWritePoFiles(): void
     {
         // set localePath using reflection class
         $localePath = sprintf('%s/tests/files/gettext/app/resources/locales', getcwd());
@@ -250,7 +251,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      * @dataProvider fixStringProvider
      * @covers ::fixString()
      */
-    public function testFixString($input, $expected)
+    public function testFixString($input, $expected): void
     {
         $method = self::getMethod('fixString');
         $args = [ $input ];
@@ -259,24 +260,108 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     }
 
     /**
+     * Provider for 'testParseFile'
+     *
+     * @return array
+     */
+    public function parseFileProvider(): array
+    {
+        return [
+            'no twig, no php extension file' => [
+                sprintf('%s/tests/files/gettext/contents/sample.js', getcwd()),
+                'js',
+                [],
+            ],
+            'empty php file' => [
+                sprintf('%s/tests/files/gettext/contents/empty.php', getcwd()),
+                'php',
+                [],
+            ],
+            'sample php' => [
+                sprintf('%s/tests/files/gettext/contents/sample.php', getcwd()),
+                'php',
+                [
+                    '1 test __',
+                    '1 test __d',
+                    '1 test __dn',
+                    '1 test __dx',
+                    '1 test __dxn',
+                    '1 test __n',
+                    '1 test __x',
+                    '1 test __xn',
+                    '2 test __',
+                    '3 test __',
+                    '4 test __',
+                    'A php content',
+                    'A php string with \'single quotes\'',
+                    'A php string with \"double quotes\"',
+                    'This is a php sample',
+                ],
+            ],
+            'sample twig' => [
+                sprintf('%s/tests/files/gettext/contents/sample.twig', getcwd()),
+                'twig',
+                [
+                    'A twig content',
+                    'A twig string with \'single quotes\'',
+                    'A twig string with \"double quotes\"',
+                    'This is a twig sample',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test 'parseFile'
+     *
+     * @param string $file The file to parse
+     * @param string $extension The file extension
+     * @param array $expected The po result array
+     * @return void
+     *
+     * @dataProvider parseFileProvider
+     * @covers ::parseFile()
+     */
+    public function testParseFile(string $file, string $extension, array $expected): void
+    {
+        $method = self::getMethod('parseFile');
+        $method->invokeArgs($this->shell, [ $file, $extension ]);
+        $actual = $this->shell->poResult;
+        sort($expected);
+        sort($actual);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
      * Provider for 'testParseDir'
      *
      * @return array
      */
-    public function parseDirProvider()
+    public function parseDirProvider(): array
     {
         return [
             'contents dir' => [
                 sprintf('%s/tests/files/gettext/contents', getcwd()), // dir
                 [
-                    'This is a twig sample',
-                    'A twig content',
-                    'A twig string with \"double quotes\"',
-                    "A twig string with 'single quotes'",
-                    'This is a php sample',
+                    '1 test __',
+                    '1 test __d',
+                    '1 test __dn',
+                    '1 test __dx',
+                    '1 test __dxn',
+                    '1 test __n',
+                    '1 test __x',
+                    '1 test __xn',
+                    '2 test __',
+                    '3 test __',
+                    '4 test __',
                     'A php content',
+                    'A php string with \'single quotes\'',
                     'A php string with \"double quotes\"',
-                    "A php string with 'single quotes'",
+                    'A twig content',
+                    'A twig string with \'single quotes\'',
+                    'A twig string with \"double quotes\"',
+                    'This is a php sample',
+                    'This is a twig sample',
                 ], // result
             ],
         ];
@@ -292,13 +377,19 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      * @covers ::parseDir()
      * @covers ::parseFile()
      * @covers ::parseContent()
+     * @covers ::parseContentSecondArg()
+     * @covers ::parseContentThirdArg()
+     * @covers ::strposX()
      * @covers ::fixString()
      */
-    public function testParseDir(string $dir, array $expected)
+    public function testParseDir(string $dir, array $expected): void
     {
         $method = self::getMethod('parseDir');
         $method->invokeArgs($this->shell, [ $dir ]);
-        static::assertEquals($expected, $this->shell->poResult, '', 0, 10, true);
+        $actual = $this->shell->poResult;
+        sort($expected);
+        sort($actual);
+        static::assertEquals($expected, $actual);
     }
 
     /**
@@ -307,7 +398,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      * @param string $name The method name
      * @return \ReflectionMethod
      */
-    protected static function getMethod($name)
+    protected static function getMethod($name): \ReflectionMethod
     {
         $class = new \ReflectionClass('BEdita\I18n\Shell\GettextShell');
         $method = $class->getMethod($name);
@@ -321,7 +412,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    private function cleanFiles()
+    private function cleanFiles(): void
     {
         $files = [
             sprintf('%s/tests/files/gettext/app/resources/locales/master.pot', getcwd()),

--- a/tests/files/gettext/contents/empty.php
+++ b/tests/files/gettext/contents/empty.php
@@ -1,2 +1,0 @@
-<?php
-declare(strict_types=1);

--- a/tests/files/gettext/contents/sample.php
+++ b/tests/files/gettext/contents/sample.php
@@ -1,10 +1,33 @@
 <?php
-declare(strict_types=1);
 
     __('This is a php sample', true);
-
     __('A php content', true);
-
     __('A php string with "double quotes"', true);
-
     __('A php string with \'single quotes\'', true);
+
+    // __
+    __('1 test __');
+    __('2 test __', true);
+    __('3 test __', true);
+    __('4 test __', true);
+
+    // __n
+    __n('1 test __n', '1 test __n plural', 1, null);
+
+    // __d
+    __d('DomainSampleD', '1 test __d', null);
+
+    // __dn
+    __dn('DomainSampleDN', '1 test __dn', '1 test __dn plural', 1, null);
+
+    // __x
+    __x('ContextSampleX', '1 test __x', null);
+
+    // __xn
+    __xn('ContextSampleXN', '1 test __xn', '1 test __xn plural', 1, null);
+
+    // __dx
+    __dx('DomainSampleDX', 'ContextSampleDX', '1 test __dx', null);
+
+    // __dxn
+    __dxn('DomainSampleDXN', 'ContextSampleDXN', '1 test __dxn', '1 test __dxn plural', 1, null);


### PR DESCRIPTION
This provides an update so that `bin/cake gettext update` extract all cakephp translation functions as:

```
  __('Something from __' , null)
  __n('Something from __n' , 'Something from __n plural', 1, null)
  __d('DomainSampleD', 'Something from __d', null)
  __dn('DomainSampleDN', 'Something from __dn', 'Something from __dn plural', 1, null)
  __x('ContextSampleX', 'Something from __x' , null)
  __xn('ContextSampleXN', 'Something from __xn' , 'Something from __xn plural', 1, null)
  __dx('DomainSampleDX', 'ContextSampleDX', 'Something from __dx', null)
  __dxn('DomainSampleDXN', 'ContextSampleDXN', 'Something from __dxn', 'Something from __dxn plural', 1, null)
```

Rif: https://chialab.atlassian.net/browse/BEM-39