### PR TITLE
Storage locale into session

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           vendor/bin/phpcs -n -p --extensions=php \
             --standard=vendor/cakephp/cakephp-codesniffer/CakePHP \
+            --ignore=test/files \
             ./config ./src ./tests
 
   stan:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=7.2",
         "ext-intl": "*",
-        "cakephp/cakephp": "^3.8.3|~4.2.2",
+        "cakephp/cakephp": "^3.8.3|^4.2.2",
         "laminas/laminas-diactoros": "^1.4.0|^2.2.2",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6|^7|^8",
         "psr/http-server-middleware": "^1.0",
-        "cakephp/cakephp-codesniffer": "~4.2.0"
+        "cakephp/cakephp-codesniffer": "^4.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,16 +17,9 @@
         </testsuite>
     </testsuites>
 
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener
-        class="\Cake\TestSuite\Fixture\FixtureInjector"
-        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+    </extensions>
 
     <filter>
         <whitelist>

--- a/src/Middleware/I18nMiddleware.php
+++ b/src/Middleware/I18nMiddleware.php
@@ -22,8 +22,8 @@ use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\I18n\FrozenTime;
 use Cake\I18n\I18n;
-use Cake\I18n\Time;
 use Cake\Utility\Hash;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -213,7 +213,7 @@ class I18nMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        $expire = Time::createFromTimestamp(strtotime($this->getConfig('cookie.expire', '+1 year')));
+        $expire = FrozenTime::createFromTimestamp(strtotime($this->getConfig('cookie.expire', '+1 year')));
 
         return $response->withCookie(new Cookie($name, $locale, $expire));
     }

--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -348,11 +348,13 @@ class GettextShell extends Shell
      */
     private function parseContent($start, $content, $options): void
     {
+        // phpcs:disable
         $rgxp = '/' .
             "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . "([^{$options['double_quote']}]*)" . "{$options['double_quote']}" .
             '|' .
             "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . "([^{$options['quote']}]*)" . "{$options['quote']}" .
             '/';
+        // phpcs:enable
         $matches = [];
         preg_match_all($rgxp, $content, $matches);
 
@@ -378,10 +380,12 @@ class GettextShell extends Shell
      */
     private function parseContentSecondArg($start, $content, $options): void
     {
+        // phpcs:disable
         $rgxp =
             '/' . "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . '([^{)}]*)' . "{$options['double_quote']}" .
             '|' . "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . '([^{)}]*)' . "{$options['quote']}" .
             '/';
+        // phpcs:enable
         $matches = [];
         preg_match_all($rgxp, $content, $matches);
 
@@ -412,10 +416,12 @@ class GettextShell extends Shell
      */
     private function parseContentThirdArg($start, $content, $options): void
     {
+        // phpcs:disable
         $rgxp =
             '/' . "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . '([^{)}]*)' . "{$options['double_quote']}" .
             '|' . "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . '([^{)}]*)' . "{$options['quote']}" .
             '/';
+        // phpcs:enable
         $matches = [];
         preg_match_all($rgxp, $content, $matches);
 

--- a/tests/TestCase/Middleware/I18nMiddlewareTest.php
+++ b/tests/TestCase/Middleware/I18nMiddlewareTest.php
@@ -86,6 +86,7 @@ class I18nMiddlewareTest extends TestCase
         I18n::setLocale(I18n::getDefaultLocale());
         Configure::delete('I18n');
         $this->requestHandler = null;
+        unset($_SESSION);
     }
 
     /**
@@ -503,6 +504,50 @@ class I18nMiddlewareTest extends TestCase
                     'new' => 'it',
                 ],
             ],
+            'ok session' => [
+                [
+                    'location' => '/home',
+                    'status' => 302,
+                    'session' => 'it_IT',
+                ],
+                [
+                    'sessionKey' => 'I18nSessionLocale',
+                    'switchLangUrl' => '/lang',
+                ],
+                [
+                    'HTTP_HOST' => 'example.com',
+                    'REQUEST_URI' => '/lang',
+                    'HTTP_REFERER' => '/home',
+                    'HTTP_ACCEPT_LANGUAGE' => 'en-US',
+                ],
+                [
+                    'new' => 'it',
+                ],
+            ],
+            'ok cookie and session' => [
+                [
+                    'location' => '/home',
+                    'status' => 302,
+                    'cookie' => 'it_IT',
+                ],
+                [
+                    'cookie' => [
+                        'name' => 'i18nLocal',
+                        'create' => true,
+                    ],
+                    'sessionKey' => 'I18nSessionLocale',
+                    'switchLangUrl' => '/lang',
+                ],
+                [
+                    'HTTP_HOST' => 'example.com',
+                    'REQUEST_URI' => '/lang',
+                    'HTTP_REFERER' => '/home',
+                    'HTTP_ACCEPT_LANGUAGE' => 'en-US',
+                ],
+                [
+                    'new' => 'it',
+                ],
+            ],
             'no query' => [
                 new BadRequestException('Missing required "new" query string'),
                 [
@@ -530,11 +575,8 @@ class I18nMiddlewareTest extends TestCase
                     'redirect' => '/home',
                 ],
             ],
-            'no cookie' => [
-                [
-                    'location' => '',
-                    'status' => 200,
-                ],
+            'no cookie, no session' => [
+                new \LogicException('I18nMiddleware misconfigured. `switchLangUrl` requires `cookie.name` or `sessionKey`'),
                 [
                     'switchLangUrl' => '/lang',
                 ],
@@ -558,6 +600,8 @@ class I18nMiddlewareTest extends TestCase
      * @dataProvider changeLangProvider
      * @covers ::changeLangAndRedirect()
      * @covers ::process()
+     * @covers ::updateSession()
+     * @covers ::getSessionKey()
      */
     public function testChangeLangAndRedirect($expected, $conf, $server, $query): void
     {
@@ -581,5 +625,98 @@ class I18nMiddlewareTest extends TestCase
             static::assertInstanceOf(Cookie::class, $cookie);
             static::assertEquals($expected['cookie'], $cookie->getValue());
         }
+
+        if (array_key_exists('session', $expected)) {
+            static::assertEquals($expected['session'], $request->getSession()->read($conf['sessionKey']));
+        }
+    }
+
+    /**
+     * Test that the session was updated with locale detected from request.
+     *
+     * @return void
+     * @covers ::process()
+     * @covers ::updateSession()
+     */
+    public function testSessionFallback(): void
+    {
+        $sessionKey = 'I18nSessionLocale';
+        $server = [
+            'HTTP_HOST' => 'example.com',
+            'REQUEST_URI' => '/help',
+            'HTTP_ACCEPT_LANGUAGE' => 'it-IT',
+        ];
+        $request = ServerRequestFactory::fromGlobals($server, null, null);
+
+        static::assertNull($request->getSession()->read($sessionKey));
+        $middleware = new I18nMiddleware(['sessionKey' => $sessionKey]);
+        $middleware->process($request, $this->requestHandler);
+
+        static::assertEquals('it_IT', I18n::getLocale());
+        static::assertEquals('it_IT', $request->getSession()->read($sessionKey));
+    }
+
+    /**
+     * Test that locale is set reading from session.
+     *
+     * @return void
+     * @covers ::process()
+     * @covers ::detectLocale()
+     * @covers ::readSession()
+     * @covers ::updateSession()
+     * @covers ::getResponseWithCookie()
+     */
+    public function testGetLocaleFromSession(): void
+    {
+        $sessionKey = 'I18nSessionLocale';
+        $server = [
+            'HTTP_HOST' => 'example.com',
+            'REQUEST_URI' => '/help',
+            'HTTP_ACCEPT_LANGUAGE' => 'en-EN',
+        ];
+        $request = ServerRequestFactory::fromGlobals($server, null, null);
+        $request->getSession()->write($sessionKey, 'it_IT');
+
+        $middleware = new I18nMiddleware(['sessionKey' => $sessionKey]);
+        $middleware->process($request, $this->requestHandler);
+
+        static::assertEquals('it_IT', I18n::getLocale());
+        static::assertEquals('it_IT', $request->getSession()->read($sessionKey));
+    }
+
+    /**
+     * Test that locale is set reading from cookie when cookie and session are both configured.
+     *
+     * @return void
+     * @covers ::process()
+     * @covers ::detectLocale()
+     * @covers ::updateSession()
+     * @covers ::getResponseWithCookie()
+     */
+    public function testGetLocaleFromCookie(): void
+    {
+        $cookieName = 'I18nCookieLocale';
+        $sessionKey = 'I18nSessionLocale';
+        $server = [
+            'HTTP_HOST' => 'example.com',
+            'REQUEST_URI' => '/help',
+            'HTTP_ACCEPT_LANGUAGE' => 'en-EN',
+        ];
+        $request = ServerRequestFactory::fromGlobals($server, null, null, [$cookieName => 'it_IT']);
+        $request->getSession()->write($sessionKey, 'en_EN');
+
+        $middleware = new I18nMiddleware([
+            'sessionKey' => $sessionKey,
+            'cookie' => [
+                'name' => $cookieName,
+                'create' => true,
+            ],
+        ]);
+        /** @var \Cake\Http\Response $response */
+        $response = $middleware->process($request, $this->requestHandler);
+
+        static::assertEquals('it_IT', I18n::getLocale());
+        static::assertEquals('it_IT', $request->getSession()->read($sessionKey)); // session is updated
+        static::assertEquals('it_IT', $response->getCookieCollection()->get($cookieName)->getValue()); // session is updated
     }
 }

--- a/tests/TestCase/Middleware/I18nMiddlewareTest.php
+++ b/tests/TestCase/Middleware/I18nMiddlewareTest.php
@@ -323,6 +323,7 @@ class I18nMiddlewareTest extends TestCase
      * @return void
      * @dataProvider setupLocaleProvider
      * @covers ::detectLocale()
+     * @covers ::readSession()
      * @covers ::setupLocale()
      */
     public function testSetupLocale(array $expected, array $server): void

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -29,12 +29,12 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     /**
      * The shell for test
      *
-     * @var GettextShell
+     * @var \BEdita\I18n\Shell\GettextShell
      */
     protected $shell = null;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function setUp(): void
     {
@@ -51,7 +51,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function tearDown(): void
     {

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -92,7 +92,8 @@ class I18nHelperTest extends TestCase
             'lang' => 'en',
         ]);
 
-        Router::connect(
+        $routeBuilder = Router::createRouteBuilder('/');
+        $routeBuilder->connect(
             '/test',
             ['controller' => 'TestApp', 'action' => 'test'],
             ['_name' => 'test']
@@ -108,6 +109,7 @@ class I18nHelperTest extends TestCase
 
         $this->I18n = null;
         Configure::delete('I18n');
+        Router::reload();
     }
 
     /**

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -98,6 +98,7 @@ class I18nHelperTest extends TestCase
             ['controller' => 'TestApp', 'action' => 'test'],
             ['_name' => 'test']
         );
+        Router::setRouteCollection(Router::getRouteCollection());
     }
 
     /**

--- a/tests/files/gettext/contents/empty.php
+++ b/tests/files/gettext/contents/empty.php
@@ -1,2 +1,0 @@
-<?php
-declare(strict_types=1);

--- a/tests/files/gettext/contents/empty.php
+++ b/tests/files/gettext/contents/empty.php
@@ -1,0 +1,2 @@
+<?php
+declare(strict_types=1);


### PR DESCRIPTION
With this PR is possible to setup a session key where to store the locale. This is useful when preferences cookies are disabled for example for GDPR.

A new `sessionKey` config key is added to `I18nMiddleware`.
Setting it to `null` (default) to avoid using session.

Setting both cookie and session the locale will be saved in both but detected from cookie first.