### PR TITLE
Add phpstan/phpstan 1.5 + fix php workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -66,7 +66,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '7.4'
-          tools: 'composer:v2'
+          tools: 'composer'
           extensions: 'mbstring, intl'
           coverage: 'none'
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -87,8 +87,7 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHP STAN'
-        run: |
-          vendor/bin/phpstan analyse --no-progress --error-format=github
+        run: 'vendor/bin/phpstan analyse --no-progress --error-format=github'
 
   undeclared-dependencies:
     name: 'Check missing dependencies'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -66,7 +66,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '7.4'
-          tools: 'composer:v2, phpstan'
+          tools: 'composer:v2'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: 'Run PHP STAN'
         run: |
-          phpstan analyse --no-progress src
+          vendor/bin/phpstan analyse --no-progress --error-format=github
 
   undeclared-dependencies:
     name: 'Check missing dependencies'

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /provision/*
 /vendor/*
 !/vendor/.gitkeep
+/phpstan.neon
 .phpunit.result.cache
 
 # IDE and editor specific files #

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
+        "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^6|^7|^8",
         "psr/http-server-middleware": "^1.0",
         "cakephp/cakephp-codesniffer": "^4.2.0"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+  level: 0

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,4 +4,5 @@ parameters:
   paths:
     - src
     - tests
-  level: 0
+  level: 4
+  checkMissingIterableValueType: false

--- a/src/Middleware/I18nMiddleware.php
+++ b/src/Middleware/I18nMiddleware.php
@@ -201,11 +201,11 @@ class I18nMiddleware implements MiddlewareInterface
      *
      * The cookie is added only if the middleware is configured to create cookie.
      *
-     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param \Cake\Http\Response $response The response.
      * @param string $locale The locale string to set in cookie.
      * @return \Psr\Http\Message\ResponseInterface
      */
-    protected function getResponseWithCookie(ResponseInterface $response, string $locale): ResponseInterface
+    protected function getResponseWithCookie(Response $response, string $locale): ResponseInterface
     {
         $name = $this->getConfig('cookie.name');
         $create = $this->getConfig('cookie.create', false);

--- a/src/Middleware/I18nMiddleware.php
+++ b/src/Middleware/I18nMiddleware.php
@@ -180,13 +180,13 @@ class I18nMiddleware implements MiddlewareInterface
     protected function setupLocale(?string $locale): void
     {
         $locales = $this->getLocales();
-        $lang = Hash::get($locales, (string)$locale);
-        if ($lang === null) {
+        $lang = (string)Hash::get($locales, (string)$locale);
+        if (empty($lang)) {
             $lang = $this->getDefaultLang();
             $locale = array_search($lang, $locales);
         }
 
-        if ($lang === null || $locale === false) {
+        if (empty($lang) || $locale === false) {
             throw new InternalErrorException(
                 __('Something was wrong with I18n configuration. Check "I18n.locales" and "I18n.default"')
             );

--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -93,6 +93,38 @@ class GettextShell extends Shell
     protected $poName = 'default.po';
 
     /**
+     * Get po result
+     */
+    public function getPoResult(): array
+    {
+        return $this->poResult;
+    }
+
+    /**
+     * Get templatePaths
+     */
+    public function getTemplatePaths(): array
+    {
+        return $this->templatePaths;
+    }
+
+    /**
+     * Get localePath
+     */
+    public function getLocalePath(): string
+    {
+        return $this->localePath;
+    }
+
+    /**
+     * Get po name
+     */
+    public function getPoName(): string
+    {
+        return $this->poName;
+    }
+
+    /**
      * Update gettext po files
      *
      * @return void

--- a/src/View/Helper/I18nHelper.php
+++ b/src/View/Helper/I18nHelper.php
@@ -57,7 +57,7 @@ class I18nHelper extends Helper
      */
     public function changeUrlLang($newLang, $switchUrl = null): string
     {
-        $request = Router::getRequest(true);
+        $request = Router::getRequest();
         if (empty($request)) {
             return '';
         }

--- a/tests/TestCase/Core/I18nTraitTest.php
+++ b/tests/TestCase/Core/I18nTraitTest.php
@@ -66,7 +66,7 @@ class I18nTraitTest extends TestCase
     {
         parent::tearDown();
 
-        $this->subject = null;
+        unset($this->subject);
         Configure::delete('I18n');
     }
 
@@ -96,6 +96,8 @@ class I18nTraitTest extends TestCase
     /**
      * Test `getLangName()`
      *
+     * @param string|null $expected The expected lang
+     * @param string|null $lang The lang in input
      * @return void
      * @dataProvider getLangNameProvider
      * @covers ::getLangName()

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -56,6 +56,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     public function tearDown(): void
     {
         $this->cleanFiles();
+        unset($this->shell);
         parent::tearDown();
     }
 
@@ -64,6 +65,10 @@ class GettextShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      * @covers ::update()
+     * @covers ::getPoResult()
+     * @covers ::getTemplatePaths()
+     * @covers ::getLocalePath()
+     * @covers ::getPoName()
      */
     public function testUpdate(): void
     {
@@ -83,6 +88,10 @@ class GettextShellTest extends ConsoleIntegrationTestCase
             $content = file_get_contents(sprintf('%s/%s/default.po', $localePath, $locale));
             static::assertNotEmpty($content);
         }
+        static::assertIsArray($this->shell->getPoResult());
+        static::assertIsArray($this->shell->getPoResult());
+        static::assertIsString($this->shell->getLocalePath());
+        static::assertIsString($this->shell->getPoName());
     }
 
     /**

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -90,8 +90,8 @@ class GettextShellTest extends ConsoleIntegrationTestCase
         }
         static::assertTrue(gettype($this->shell->getPoResult()) === 'array');
         static::assertTrue(gettype($this->shell->getTemplatePaths()) === 'array');
-        static::assertIsString($this->shell->getLocalePath());
-        static::assertIsString($this->shell->getPoName());
+        static::assertTrue(gettype($this->shell->getLocalePath() === 'string'));
+        static::assertTrue(gettype($this->shell->getPoName() === 'string'));
     }
 
     /**

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -247,8 +247,8 @@ class GettextShellTest extends ConsoleIntegrationTestCase
                 "something 'quoted'", // expected
             ],
             'new lines' => [
-                sprintf('something%swith%snew%slines', "\n", "\n", "\n", "\n"), // input
-                sprintf('something%swith%snew%slines', '\n', '\n', '\n', '\n'), // expected
+                sprintf('something%swith%snew%slines', "\n", "\n", "\n"), // input
+                sprintf('something%swith%snew%slines', '\n', '\n', '\n'), // expected
             ],
         ];
     }

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -88,8 +88,8 @@ class GettextShellTest extends ConsoleIntegrationTestCase
             $content = file_get_contents(sprintf('%s/%s/default.po', $localePath, $locale));
             static::assertNotEmpty($content);
         }
-        $this->assertIsArray($this->shell->getPoResult());
-        $this->assertIsArray($this->shell->getPoResult());
+        static::assertTrue(gettype($this->shell->getPoResult()) === 'array');
+        static::assertTrue(gettype($this->shell->getTemplatePaths()) === 'array');
         static::assertIsString($this->shell->getLocalePath());
         static::assertIsString($this->shell->getPoName());
     }

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -90,8 +90,8 @@ class GettextShellTest extends ConsoleIntegrationTestCase
         }
         static::assertTrue(gettype($this->shell->getPoResult()) === 'array');
         static::assertTrue(gettype($this->shell->getTemplatePaths()) === 'array');
-        static::assertTrue(gettype($this->shell->getLocalePath() === 'string'));
-        static::assertTrue(gettype($this->shell->getPoName() === 'string'));
+        static::assertTrue(gettype($this->shell->getLocalePath()) === 'string');
+        static::assertTrue(gettype($this->shell->getPoName()) === 'string');
     }
 
     /**

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -148,19 +148,19 @@ class GettextShellTest extends ConsoleIntegrationTestCase
         $method = self::getMethod('setupPaths');
         $method->invokeArgs($this->shell, []);
         $i = 0;
-        $actualPaths = $this->shell->templatePaths;
+        $actualPaths = $this->shell->getTemplatePaths();
         foreach ($actualPaths as &$actual) {
             if (strlen($actual) !== strlen($expectedTemplatePaths[$i++])) {
                 $actual = substr($actual, 0, -1);
             }
         }
         static::assertEquals($expectedTemplatePaths, $actualPaths);
-        $actual = $this->shell->localePath;
+        $actual = $this->shell->getLocalePath();
         if (strlen($actual) !== strlen($expectedLocalePath)) {
             $actual = substr($actual, 0, -1);
         }
         static::assertEquals($expectedLocalePath, $actual);
-        static::assertEquals($expectedPoName, $this->shell->poName);
+        static::assertEquals($expectedPoName, $this->shell->getPoName());
     }
 
     /**
@@ -336,7 +336,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     {
         $method = self::getMethod('parseFile');
         $method->invokeArgs($this->shell, [ $file, $extension ]);
-        $actual = $this->shell->poResult;
+        $actual = $this->shell->getPoResult();
         sort($expected);
         sort($actual);
         static::assertEquals($expected, $actual);
@@ -396,7 +396,7 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     {
         $method = self::getMethod('parseDir');
         $method->invokeArgs($this->shell, [ $dir ]);
-        $actual = $this->shell->poResult;
+        $actual = $this->shell->getPoResult();
         sort($expected);
         sort($actual);
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -88,8 +88,8 @@ class GettextShellTest extends ConsoleIntegrationTestCase
             $content = file_get_contents(sprintf('%s/%s/default.po', $localePath, $locale));
             static::assertNotEmpty($content);
         }
-        static::assertIsArray($this->shell->getPoResult());
-        static::assertIsArray($this->shell->getPoResult());
+        $this->assertIsArray($this->shell->getPoResult());
+        $this->assertIsArray($this->shell->getPoResult());
         static::assertIsString($this->shell->getLocalePath());
         static::assertIsString($this->shell->getPoName());
     }

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -108,7 +108,7 @@ class I18nHelperTest extends TestCase
     {
         parent::tearDown();
 
-        $this->I18n = null;
+        unset($this->I18n);
         Configure::delete('I18n');
         Router::reload();
     }
@@ -174,7 +174,7 @@ class I18nHelperTest extends TestCase
      * @param string $expected The string expected
      * @param array $server The server vars
      * @param string $lang The language to change
-     * @param string $lang The switch language url
+     * @param string $switchUrl The switch language url
      * @return void
      * @dataProvider changeUrlLangProvider
      * @covers ::changeUrlLang()
@@ -199,8 +199,9 @@ class I18nHelperTest extends TestCase
      */
     public function fieldProvider(): array
     {
-        $objectBase = ['id' => $this->object['id']] + $this->object['attributes'];
-        $objectStructured = $this->object;
+        $objectStructured = (array)$this->object;
+        $objectBase = (array)$objectStructured['attributes'];
+        $objectBase['id'] = $objectStructured['id'];
 
         $included = $this->included;
 


### PR DESCRIPTION
This updates `php` workflow, so that `phpstan` dependency version is used (instead of downloading it with composer, during CI).

This activity in bedita started with https://github.com/bedita/bedita/pull/1889