### PR TITLE
4.x / master: fix gettext setup plugin paths

### DIFF
--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -569,7 +569,7 @@ class GettextCommand extends Command
         }
         // check template folder exists
         $plugin = $args->getOption('plugin');
-        $appDir = empty($plugin) ? App::path(View::NAME_TEMPLATE)[0] : Plugin::templatePath($plugin);
+        $appDir = (!empty($plugin) && is_string($plugin)) ? Plugin::templatePath($plugin) : App::path(View::NAME_TEMPLATE)[0];
         if (!file_exists($appDir)) {
             $io->out(sprintf('Skip javascript parsing - %s folder not found', $appDir));
 

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -569,7 +569,7 @@ class GettextCommand extends Command
         }
         // check template folder exists
         $plugin = $args->getOption('plugin');
-        $appDir = (!empty($plugin) && is_string($plugin)) ? Plugin::templatePath($plugin) : App::path(View::NAME_TEMPLATE)[0];
+        $appDir = !empty($plugin) && is_string($plugin) ? Plugin::templatePath($plugin) : App::path(View::NAME_TEMPLATE)[0];
         if (!file_exists($appDir)) {
             $io->out(sprintf('Skip javascript parsing - %s folder not found', $appDir));
 

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -179,11 +179,9 @@ class GettextCommand extends Command
 
             return;
         }
-        $this->templatePaths = [APP, CONFIG];
         $app = $args->getOption('app');
-        if ($app) {
-            $this->templatePaths = [$app . DS . 'src', $app . DS . 'config'];
-        }
+        $basePath = $app ?? getcwd();
+        $this->templatePaths = [$basePath . DS . 'src', $basePath . DS . 'config'];
         $this->templatePaths = array_merge($this->templatePaths, App::path(View::NAME_TEMPLATE));
         $this->templatePaths = array_filter($this->templatePaths, function ($path) {
             return strpos($path, 'plugins') === false;

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -180,6 +180,10 @@ class GettextCommand extends Command
             return;
         }
         $this->templatePaths = [APP, CONFIG];
+        $app = $args->getOption('app');
+        if ($app) {
+            $this->templatePaths = [$app . DS . 'src', $app . DS . 'config'];
+        }
         $this->templatePaths = array_merge($this->templatePaths, App::path(View::NAME_TEMPLATE));
         $this->templatePaths = array_filter($this->templatePaths, function ($path) {
             return strpos($path, 'plugins') === false;

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -569,7 +569,7 @@ class GettextCommand extends Command
         }
         // check template folder exists
         $plugin = $args->getOption('plugin');
-        $appDir = !empty($plugin) && is_string($plugin) ? Plugin::templatePath($plugin) : App::path(View::NAME_TEMPLATE)[0];
+        $appDir = !empty($plugin) && is_string($plugin) ? Plugin::templatePath($plugin) : Hash::get(App::path(View::NAME_TEMPLATE), 0);
         if (!file_exists($appDir)) {
             $io->out(sprintf('Skip javascript parsing - %s folder not found', $appDir));
 

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -163,7 +163,7 @@ class GettextCommand extends Command
     {
         $plugin = $args->getOption('plugin');
         $localesPaths = (array)App::path('locales');
-        if ($plugin) {
+        if ($plugin && is_string($plugin)) {
             $paths = [
                 Plugin::classPath($plugin),
                 Plugin::configPath($plugin),

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -121,7 +121,7 @@ class GettextCommandTest extends TestCase
                 [
                     sprintf('%s/tests/test_app/plugins/Dummy/src', $base),
                     sprintf('%s/tests/test_app/plugins/Dummy/config', $base),
-                    sprintf('%s/tests/test_app/plugins/Dummy/Template', $base),
+                    sprintf('%s/tests/test_app/plugins/Dummy/templates', $base),
                 ], // template paths
                 sprintf('%s/tests/test_app/plugins/Dummy/Locale', $base), // locale path
             ],


### PR DESCRIPTION
This fixes an issue in "setup plugin paths", correcting the buggy behaviour of "get first plugin".

This is a clone of https://github.com/bedita/i18n/pull/55, but for 4.x