### PR TITLE
Fix ttagExtract pot filename for plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=7.4",
         "ext-intl": "*",
-        "cakephp/cakephp": "^4.2.2",
+        "cakephp/cakephp": "^4.4",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "autoload-dev": {
         "psr-4": {
             "BEdita\\I18n\\Test\\": "tests",
+            "Cake\\": "./vendor/cakephp/cakephp/src",
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests",
             "TestApp\\": "tests/test_app/TestApp/"
         }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=7.4",
         "ext-intl": "*",
-        "cakephp/cakephp": "^4.4",
+        "cakephp/cakephp": "^4.2.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
@@ -20,7 +20,8 @@
         "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^9",
         "psr/http-server-middleware": "^1.0",
-        "cakephp/cakephp-codesniffer": "^4.2.0"
+        "cakephp/cakephp-codesniffer": "^4.2.0",
+        "cakephp/console": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -581,8 +581,9 @@ class GettextCommand extends Command
         $defaultJs = sprintf('%s/default-js.pot', $this->localePath);
         exec(sprintf('%s extract --o %s --l en %s', $ttag, $defaultJs, $appDir));
 
-        // merge default-js.pot and default.pot
-        $default = sprintf('%s/default.pot', $this->localePath);
+        // merge default-js.pot and <plugin>.pot|default.pot
+        $potFile = !empty($plugin) && is_string($plugin) ? sprintf('%s.pot', $plugin) : 'default.pot';
+        $default = sprintf('%s/%s', $this->localePath, $potFile);
         exec(sprintf('msgcat --use-first %s %s -o %s', $default, $defaultJs, $default));
 
         // remove default-js.pot

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -6,8 +6,8 @@ namespace BEdita\I18n\Test\TestCase\Command;
 use BEdita\I18n\Command\GettextCommand;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
-use Cake\Console\TestSuite\ConsoleIntegrationTestTrait
-use Cake\Core\Configure;;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -17,7 +17,7 @@ use Cake\TestSuite\TestCase;
  */
 class GettextCommandTest extends TestCase
 {
-    use ConsoleIntegrationTestTrait;
+    use ConsoleIntegrationTestTrait; /** @phpstan-ignore-line */
 
     /**
      * The command used in test
@@ -40,7 +40,7 @@ class GettextCommandTest extends TestCase
             ],
         ]);
         parent::setUp();
-        $this->useCommandRunner();
+        $this->useCommandRunner(); /** @phpstan-ignore-line */
         $this->command = new GettextCommand();
         $this->cleanFiles();
     }
@@ -62,7 +62,7 @@ class GettextCommandTest extends TestCase
      */
     public function testBuildOptionParser(): void
     {
-        $this->exec('gettext --help');
+        $this->exec('gettext --help'); /** @phpstan-ignore-line */
         $this->assertOutputContains('Create or update i18n po/pot files');
         $this->assertOutputContains('bin/cake gettext');
     }
@@ -84,7 +84,7 @@ class GettextCommandTest extends TestCase
 
         // call the method
         $appPath = sprintf('%s/tests/test_app/TestApp', getcwd());
-        $this->exec('gettext --app ' . $appPath);
+        $this->exec('gettext --app ' . $appPath); /** @phpstan-ignore-line */
 
         // check po files are not empty
         foreach (['en_US', 'it_IT'] as $locale) {

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -7,7 +7,7 @@ use BEdita\I18n\Command\GettextCommand;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;/** @phpstan-ignore-line */
 use Cake\TestSuite\TestCase;
 
 /**
@@ -17,7 +17,7 @@ use Cake\TestSuite\TestCase;
  */
 class GettextCommandTest extends TestCase
 {
-    use ConsoleIntegrationTestTrait; /** @phpstan-ignore-line */
+    use ConsoleIntegrationTestTrait;
 
     /**
      * The command used in test
@@ -40,7 +40,7 @@ class GettextCommandTest extends TestCase
             ],
         ]);
         parent::setUp();
-        $this->useCommandRunner(); /** @phpstan-ignore-line */
+        $this->useCommandRunner();/** @phpstan-ignore-line */
         $this->command = new GettextCommand();
         $this->cleanFiles();
     }
@@ -62,9 +62,9 @@ class GettextCommandTest extends TestCase
      */
     public function testBuildOptionParser(): void
     {
-        $this->exec('gettext --help'); /** @phpstan-ignore-line */
-        $this->assertOutputContains('Create or update i18n po/pot files');
-        $this->assertOutputContains('bin/cake gettext');
+        $this->exec('gettext --help');/** @phpstan-ignore-line */
+        $this->assertOutputContains('Create or update i18n po/pot files');/** @phpstan-ignore-line */
+        $this->assertOutputContains('bin/cake gettext');/** @phpstan-ignore-line */
     }
 
     /**
@@ -84,7 +84,7 @@ class GettextCommandTest extends TestCase
 
         // call the method
         $appPath = sprintf('%s/tests/test_app/TestApp', getcwd());
-        $this->exec('gettext --app ' . $appPath); /** @phpstan-ignore-line */
+        $this->exec('gettext --app ' . $appPath);/** @phpstan-ignore-line */
 
         // check po files are not empty
         foreach (['en_US', 'it_IT'] as $locale) {

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -17,7 +17,7 @@ use Cake\TestSuite\TestCase;
  */
 class GettextCommandTest extends TestCase
 {
-    use ConsoleIntegrationTestTrait; /** @phpstan-ignore-line */
+    use ConsoleIntegrationTestTrait;
 
     /**
      * The command used in test
@@ -40,7 +40,7 @@ class GettextCommandTest extends TestCase
             ],
         ]);
         parent::setUp();
-        $this->useCommandRunner(); /** @phpstan-ignore-line */
+        $this->useCommandRunner();
         $this->command = new GettextCommand();
         $this->cleanFiles();
     }
@@ -62,7 +62,7 @@ class GettextCommandTest extends TestCase
      */
     public function testBuildOptionParser(): void
     {
-        $this->exec('gettext --help'); /** @phpstan-ignore-line */
+        $this->exec('gettext --help');
         $this->assertOutputContains('Create or update i18n po/pot files');
         $this->assertOutputContains('bin/cake gettext');
     }
@@ -84,7 +84,7 @@ class GettextCommandTest extends TestCase
 
         // call the method
         $appPath = sprintf('%s/tests/test_app/TestApp', getcwd());
-        $this->exec('gettext --app ' . $appPath); /** @phpstan-ignore-line */
+        $this->exec('gettext --app ' . $appPath);
 
         // check po files are not empty
         foreach (['en_US', 'it_IT'] as $locale) {

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -7,7 +7,7 @@ use BEdita\I18n\Command\GettextCommand;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -7,7 +7,7 @@ use BEdita\I18n\Command\GettextCommand;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
-use Cake\TestSuite\ConsoleIntegrationTestTrait;/** @phpstan-ignore-line */
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -17,7 +17,7 @@ use Cake\TestSuite\TestCase;
  */
 class GettextCommandTest extends TestCase
 {
-    use ConsoleIntegrationTestTrait;
+    use ConsoleIntegrationTestTrait; /** @phpstan-ignore-line */
 
     /**
      * The command used in test
@@ -40,7 +40,7 @@ class GettextCommandTest extends TestCase
             ],
         ]);
         parent::setUp();
-        $this->useCommandRunner();/** @phpstan-ignore-line */
+        $this->useCommandRunner(); /** @phpstan-ignore-line */
         $this->command = new GettextCommand();
         $this->cleanFiles();
     }
@@ -62,9 +62,9 @@ class GettextCommandTest extends TestCase
      */
     public function testBuildOptionParser(): void
     {
-        $this->exec('gettext --help');/** @phpstan-ignore-line */
-        $this->assertOutputContains('Create or update i18n po/pot files');/** @phpstan-ignore-line */
-        $this->assertOutputContains('bin/cake gettext');/** @phpstan-ignore-line */
+        $this->exec('gettext --help'); /** @phpstan-ignore-line */
+        $this->assertOutputContains('Create or update i18n po/pot files');
+        $this->assertOutputContains('bin/cake gettext');
     }
 
     /**
@@ -84,7 +84,7 @@ class GettextCommandTest extends TestCase
 
         // call the method
         $appPath = sprintf('%s/tests/test_app/TestApp', getcwd());
-        $this->exec('gettext --app ' . $appPath);/** @phpstan-ignore-line */
+        $this->exec('gettext --app ' . $appPath); /** @phpstan-ignore-line */
 
         // check po files are not empty
         foreach (['en_US', 'it_IT'] as $locale) {

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -6,8 +6,8 @@ namespace BEdita\I18n\Test\TestCase\Command;
 use BEdita\I18n\Command\GettextCommand;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
-use Cake\Core\Configure;
-use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait
+use Cake\Core\Configure;;
 use Cake\TestSuite\TestCase;
 
 /**


### PR DESCRIPTION
This fixes a buggy behaviour in `GettextCommand` on plugin: pot file name populated by `ttagExtract` should be `<pluginName>.pot`, in this case. `default.pot` when you launch command for app.