### PR TITLE
Backporting parsing for second argument

### DIFF
--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -427,10 +427,14 @@ class GettextShell extends Shell
      */
     private function parseContentSecondArg($start, $content, $options): void
     {
+        $capturePath = "([^']*)',\s*'([^']*)";
+        $doubleQuoteCapture = str_replace("'", $options['double_quote'], $capturePath);
+        $quoteCapture = str_replace("'", $options['quote'], $capturePath);
+
         // phpcs:disable
         $rgxp =
-            '/' . "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . '([^{)}]*)' . "{$options['double_quote']}" .
-            '|' . "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . '([^{)}]*)' . "{$options['quote']}" .
+            '/' . "${start}\s*{$options['open_parenthesis']}\s*{$options['double_quote']}" . $doubleQuoteCapture . "{$options['double_quote']}" .
+            '|' . "${start}\s*{$options['open_parenthesis']}\s*{$options['quote']}" . $quoteCapture . "{$options['quote']}" .
             '/';
         // phpcs:enable
         $matches = [];

--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -89,6 +89,13 @@ class GettextShell extends Shell
     protected $localePath = null;
 
     /**
+     * The name of default domain if not specified. Used for pot and po file names.
+     *
+     * @var string
+     */
+    protected $defaultDomain = 'default';
+
+    /**
      * PO file name
      *
      * @var string
@@ -405,14 +412,21 @@ class GettextShell extends Shell
         $matches = [];
         preg_match_all($rgxp, $content, $matches);
 
+        $domain = $this->defaultDomain;
+
         $limit = count($matches[0]);
         for ($i = 0; $i < $limit; $i++) {
             $item = $this->fixString($matches[1][$i]);
             if (empty($item)) {
                 $item = $this->fixString($matches[2][$i]);
             }
-            if (!in_array($item, $this->poResult)) {
-                $this->poResult[] = $item;
+
+            if (!array_key_exists($domain, $this->poResult)) {
+                $this->poResult[$domain] = [];
+            }
+
+            if (!in_array($item, $this->poResult[$domain])) {
+                $this->poResult[$domain][] = $item;
             }
         }
     }
@@ -442,17 +456,22 @@ class GettextShell extends Shell
 
         $limit = count($matches[0]);
         for ($i = 0; $i < $limit; $i++) {
-            $str = $matches[2][$i];
-            if (substr_count($matches[2][0], ',') === 1) {
-                $str = substr(trim(substr($str, strpos($str, ',') + 1)), 1);
-            } elseif (substr_count($matches[2][0], ',') === 2) {
-                $str = trim(substr($str, strpos($str, ',') + 1));
-                $str = trim(substr($str, 0, strpos($str, ',')));
-                $str = substr($str, 1, -1);
+            $domain = $matches[3][$i];
+            $str = $matches[4][$i];
+
+            // context not handled for now
+            if (strpos($start, '__x') === 0) {
+                $domain = $this->defaultDomain;
             }
+
             $item = $this->fixString($str);
-            if (!in_array($item, $this->poResult)) {
-                $this->poResult[] = $item;
+
+            if (!array_key_exists($domain, $this->poResult)) {
+                $this->poResult[$domain] = [];
+            }
+
+            if (!in_array($item, $this->poResult[$domain])) {
+                $this->poResult[$domain][] = $item;
             }
         }
     }
@@ -476,6 +495,8 @@ class GettextShell extends Shell
         $matches = [];
         preg_match_all($rgxp, $content, $matches);
 
+        $domain = $this->defaultDomain; // domain and context not handled yet
+
         $limit = count($matches[0]);
         for ($i = 0; $i < $limit; $i++) {
             $str = $matches[2][$i];
@@ -487,8 +508,13 @@ class GettextShell extends Shell
                 $str = substr($str, 1);
             }
             $item = $this->fixString($str);
-            if (!in_array($item, $this->poResult)) {
-                $this->poResult[] = $item;
+
+            if (!array_key_exists($domain, $this->poResult)) {
+                $this->poResult[$domain] = [];
+            }
+
+            if (!in_array($item, $this->poResult[$domain])) {
+                $this->poResult[$domain][] = $item;
             }
         }
     }

--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -96,13 +96,6 @@ class GettextShell extends Shell
     protected $defaultDomain = 'default';
 
     /**
-     * PO file name
-     *
-     * @var string
-     */
-    protected $poName = 'default.po';
-
-    /**
      * Get po result
      */
     public function getPoResult(): array
@@ -124,14 +117,6 @@ class GettextShell extends Shell
     public function getLocalePath(): string
     {
         return $this->localePath;
-    }
-
-    /**
-     * Get po name
-     */
-    public function getPoName(): string
-    {
-        return $this->poName;
     }
 
     /**
@@ -184,7 +169,7 @@ class GettextShell extends Shell
                 Plugin::configPath($plugin),
             ];
             $this->templatePaths = array_merge($paths, App::path(View::NAME_TEMPLATE, $plugin));
-            $this->poName = $this->params['plugin'] . '.po';
+            $this->defaultDomain = $plugin;
             $localesPaths = (array)Configure::read('App.paths.locales');
             foreach ($localesPaths as $path) {
                 if (strpos($path, sprintf('%s%s%s', DS, $plugin, DS)) > 0) {
@@ -214,17 +199,19 @@ class GettextShell extends Shell
      */
     private function writeMasterPot(): void
     {
-        $potFilename = sprintf('%s/master.pot', $this->localePath);
-        $this->out(sprintf('Writing new .pot file: %s', $potFilename));
-        $pot = new File($potFilename, true);
-        $pot->write($this->header('pot'));
-        sort($this->poResult);
-        foreach ($this->poResult as $res) {
-            if (!empty($res)) {
-                $pot->write(sprintf('%smsgid "%s"%smsgstr ""%s', "\n", $res, "\n", "\n"));
+        foreach ($this->poResult as $domain => $poResult) {
+            $potFilename = sprintf('%s/%s.pot', $this->localePath, $domain);
+            $this->out(sprintf('Writing new .pot file: %s', $potFilename));
+            $pot = new File($potFilename, true);
+            $pot->write($this->header('pot'));
+            sort($poResult);
+            foreach ($poResult as $res) {
+                if (!empty($res)) {
+                    $pot->write(sprintf('%smsgid "%s"%smsgstr ""%s', "\n", $res, "\n", "\n"));
+                }
             }
+            $pot->close();
         }
-        $pot->close();
     }
 
     /**
@@ -235,7 +222,6 @@ class GettextShell extends Shell
     private function writePoFiles(): void
     {
         $header = $this->header('po');
-        $potFilename = sprintf('%s/master.pot', $this->localePath);
         $locales = array_keys((array)Configure::read('I18n.locales', []));
         foreach ($locales as $loc) {
             $potDir = $this->localePath . DS . $loc;
@@ -243,17 +229,21 @@ class GettextShell extends Shell
                 mkdir($potDir);
             }
             $this->out(sprintf('Language: %s', $loc));
-            $poFile = sprintf('%s/%s', $potDir, $this->poName);
-            if (!file_exists($poFile)) {
-                $newPoFile = new File($poFile, true);
-                $newPoFile->write($header);
-                $newPoFile->close();
+
+            foreach (array_keys($this->poResult) as $domain) {
+                $potFilename = sprintf('%s/%s.pot', $this->localePath, $domain);
+                $poFile = sprintf('%s/%s.po', $potDir, $domain);
+                if (!file_exists($poFile)) {
+                    $newPoFile = new File($poFile, true);
+                    $newPoFile->write($header);
+                    $newPoFile->close();
+                }
+                $this->out(sprintf('Merging %s', $poFile));
+                $mergeCmd = sprintf('msgmerge --backup=off -N -U %s %s', $poFile, $potFilename);
+                exec($mergeCmd);
+                $this->analyzePoFile($poFile);
+                $this->hr();
             }
-            $this->out(sprintf('Merging %s', $poFile));
-            $mergeCmd = sprintf('msgmerge --backup=off -N -U %s %s', $poFile, $potFilename);
-            exec($mergeCmd);
-            $this->analyzePoFile($poFile);
-            $this->hr();
         }
     }
 
@@ -592,8 +582,8 @@ class GettextShell extends Shell
         $masterJs = sprintf('%s/master-js.pot', $this->localePath);
         exec(sprintf('%s extract --o %s --l en %s', $ttag, $masterJs, $appDir));
 
-        // merge master-js.pot and master.pot
-        $master = sprintf('%s/master.pot', $this->localePath);
+        // merge master-js.pot and default.pot
+        $master = sprintf('%s/default.pot', $this->localePath);
         exec(sprintf('msgcat --use-first %s %s -o %s', $master, $masterJs, $master));
 
         // remove master-js.pot

--- a/src/Shell/GettextShell.php
+++ b/src/Shell/GettextShell.php
@@ -446,8 +446,8 @@ class GettextShell extends Shell
 
         $limit = count($matches[0]);
         for ($i = 0; $i < $limit; $i++) {
-            $domain = $matches[3][$i];
-            $str = $matches[4][$i];
+            $domain = !empty($matches[1][$i]) ? $matches[1][$i] : $matches[3][$i];
+            $str = !empty($matches[2][$i]) ? $matches[2][$i] : $matches[4][$i];
 
             // context not handled for now
             if (strpos($start, '__x') === 0) {

--- a/tests/TestCase/Shell/GettextShellTest.php
+++ b/tests/TestCase/Shell/GettextShellTest.php
@@ -304,31 +304,42 @@ class GettextShellTest extends ConsoleIntegrationTestCase
                 sprintf('%s/tests/files/gettext/contents/sample.php', getcwd()),
                 'php',
                 [
-                    '1 test __',
-                    '1 test __d',
-                    '1 test __dn',
-                    '1 test __dx',
-                    '1 test __dxn',
-                    '1 test __n',
-                    '1 test __x',
-                    '1 test __xn',
-                    '2 test __',
-                    '3 test __',
-                    '4 test __',
-                    'A php content',
-                    'A php string with \'single quotes\'',
-                    'A php string with \"double quotes\"',
-                    'This is a php sample',
+                    'default' => [
+                        'This is a php sample',
+                        'A php content',
+                        'A php string with \"double quotes\"',
+                        'A php string with \'single quotes\'',
+                        '1 test __',
+                        '2 test __',
+                        '3 test __',
+                        '4 test __',
+                        '1 test __n',
+                        '1 test __x',
+                        '1 test __xn',
+                        '1 test __dx',
+                        '1 test __dxn',
+                    ],
+                    'DomainSampleD' => [
+                        '1 test __d',
+                    ],
+                    'DomainSampleDN' => [
+                        '1 test __dn',
+                    ],
                 ],
             ],
             'sample twig' => [
                 sprintf('%s/tests/files/gettext/contents/sample.twig', getcwd()),
                 'twig',
                 [
-                    'A twig content',
-                    'A twig string with \'single quotes\'',
-                    'A twig string with \"double quotes\"',
-                    'This is a twig sample',
+                    'default' => [
+                        'This is a twig sample',
+                        'A twig content',
+                        'A twig string with \"double quotes\"',
+                        'A twig string with \'single quotes\'',
+                    ],
+                    'DomainSampleD' => [
+                        'A twig string in a domain',
+                    ],
                 ],
             ],
         ];
@@ -347,11 +358,33 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     public function testParseFile(string $file, string $extension, array $expected): void
     {
         $method = self::getMethod('parseFile');
-        $method->invokeArgs($this->shell, [ $file, $extension ]);
+        $method->invokeArgs($this->shell, [$file, $extension]);
         $actual = $this->shell->getPoResult();
-        sort($expected);
-        sort($actual);
+        $this->recursiveSort($expected);
+        $this->recursiveSort($actual);
         static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Recursive ksort/sort arrays used in tests
+     *
+     * @param array $array Array to sort
+     * @return void
+     */
+    protected function recursiveSort(array &$array): void
+    {
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $this->recursiveSort($value);
+            }
+        }
+        if (array_values($array) === $array) {
+            sort($array);
+
+            return;
+        }
+
+        ksort($array);
     }
 
     /**
@@ -365,25 +398,32 @@ class GettextShellTest extends ConsoleIntegrationTestCase
             'contents dir' => [
                 sprintf('%s/tests/files/gettext/contents', getcwd()), // dir
                 [
-                    '1 test __',
-                    '1 test __d',
-                    '1 test __dn',
-                    '1 test __dx',
-                    '1 test __dxn',
-                    '1 test __n',
-                    '1 test __x',
-                    '1 test __xn',
-                    '2 test __',
-                    '3 test __',
-                    '4 test __',
-                    'A php content',
-                    'A php string with \'single quotes\'',
-                    'A php string with \"double quotes\"',
-                    'A twig content',
-                    'A twig string with \'single quotes\'',
-                    'A twig string with \"double quotes\"',
-                    'This is a php sample',
-                    'This is a twig sample',
+                    'default' => [
+                        'This is a twig sample',
+                        'A twig content',
+                        'A twig string with \"double quotes\"',
+                        "A twig string with 'single quotes'",
+                        'This is a php sample',
+                        'A php content',
+                        'A php string with \"double quotes\"',
+                        'A php string with \'single quotes\'',
+                        '1 test __',
+                        '2 test __',
+                        '3 test __',
+                        '4 test __',
+                        '1 test __n',
+                        '1 test __x',
+                        '1 test __xn',
+                        '1 test __dx',
+                        '1 test __dxn',
+                    ],
+                    'DomainSampleD' => [
+                        'A twig string in a domain',
+                        '1 test __d',
+                    ],
+                    'DomainSampleDN' => [
+                        '1 test __dn',
+                    ],
                 ], // result
             ],
         ];
@@ -407,10 +447,10 @@ class GettextShellTest extends ConsoleIntegrationTestCase
     public function testParseDir(string $dir, array $expected): void
     {
         $method = self::getMethod('parseDir');
-        $method->invokeArgs($this->shell, [ $dir ]);
+        $method->invokeArgs($this->shell, [$dir]);
         $actual = $this->shell->getPoResult();
-        sort($expected);
-        sort($actual);
+        $this->recursiveSort($expected);
+        $this->recursiveSort($actual);
         static::assertEquals($expected, $actual);
     }
 

--- a/tests/files/gettext/contents/sample.twig
+++ b/tests/files/gettext/contents/sample.twig
@@ -7,3 +7,5 @@
 {{ __('A twig string with \'single quotes\'', true) }}
 
 {{ __d('DomainSampleD', 'A twig string in a domain') }}
+
+{{ __d('DomainSampleD', 'A twig string in a domain with {0}') }}

--- a/tests/files/gettext/contents/sample.twig
+++ b/tests/files/gettext/contents/sample.twig
@@ -5,3 +5,5 @@
 {{ __('A twig string with "double quotes"', true) }}
 
 {{ __('A twig string with \'single quotes\'', true) }}
+
+{{ __d('DomainSampleD', 'A twig string in a domain') }}

--- a/tests/test_app/TestApp/src/sample.php
+++ b/tests/test_app/TestApp/src/sample.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+    __('This is a php sample');
+    __('A php content');
+    __('A php string with "double quotes"');
+    __('A php string with \'single quotes\'');


### PR DESCRIPTION
Backporting `parseContentSecondArg` from v4 to fix some `__d` cases.