### PR TITLE
Handle domains with double quotes

### DIFF
--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -446,8 +446,8 @@ class GettextCommand extends Command
 
         $limit = count($matches[0]);
         for ($i = 0; $i < $limit; $i++) {
-            $domain = $matches[3][$i];
-            $str = $matches[4][$i];
+            $domain = !empty($matches[1][$i]) ? $matches[1][$i] : $matches[3][$i];
+            $str = !empty($matches[2][$i]) ? $matches[2][$i] : $matches[4][$i];
 
             // context not handled for now
             if (strpos($start, '__x') === 0) {

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -345,6 +345,8 @@ class GettextCommandTest extends TestCase
                     ],
                     'DomainSampleD' => [
                         'A twig string in a domain',
+                        'A twig string in a domain in double quotes',
+                        'A twig string in a domain with {0}',
                     ],
                 ],
             ],
@@ -403,6 +405,8 @@ class GettextCommandTest extends TestCase
                     ],
                     'DomainSampleD' => [
                         'A twig string in a domain',
+                        'A twig string in a domain in double quotes',
+                        'A twig string in a domain with {0}',
                         '1 test __d',
                     ],
                     'DomainSampleDN' => [

--- a/tests/files/gettext/contents/sample.twig
+++ b/tests/files/gettext/contents/sample.twig
@@ -7,3 +7,7 @@
 {{ __('A twig string with \'single quotes\'', true) }}
 
 {{ __d('DomainSampleD', 'A twig string in a domain') }}
+
+{{ __d("DomainSampleD", "A twig string in a domain in double quotes") }}
+
+{{ __d('DomainSampleD', 'A twig string in a domain with {0}') }}


### PR DESCRIPTION
This PR fixes an issue with domain translations and double quotes: `__d("Domain", "string")`