### PR TITLE
Support for "redirect" query string switching lang

### DIFF
--- a/src/Middleware/I18nMiddleware.php
+++ b/src/Middleware/I18nMiddleware.php
@@ -25,6 +25,7 @@ use Cake\Http\ServerRequest;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\I18n;
 use Cake\Utility\Hash;
+use Cake\Validation\Validation;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -245,10 +246,15 @@ class I18nMiddleware implements MiddlewareInterface
             throw new BadRequestException(__('Lang "{0}" not supported', [$new]));
         }
 
+        $redirect = (string)$request->getQuery('redirect', $request->referer(false));
+        if (strpos($redirect, '/') !== 0 && !Validation::url($redirect, true)) {
+            throw new BadRequestException(__('"redirect" query string not valid'));
+        }
+
         $this->updateSession($request, $locale);
 
         $response = (new Response())
-            ->withLocation((string)$request->referer(false))
+            ->withLocation($redirect)
             ->withDisabledCache()
             ->withStatus(302);
 

--- a/tests/TestCase/Middleware/I18nMiddlewareTest.php
+++ b/tests/TestCase/Middleware/I18nMiddlewareTest.php
@@ -573,7 +573,6 @@ class I18nMiddlewareTest extends TestCase
                 ],
                 [
                     'new' => 'de',
-                    'redirect' => '/home',
                 ],
             ],
             'no cookie, no session' => [
@@ -586,6 +585,43 @@ class I18nMiddlewareTest extends TestCase
                     'REQUEST_URI' => '/lang',
                 ],
                 [],
+            ],
+            'invalid redirect' => [
+                new BadRequestException('"redirect" query string not valid'),
+                [
+                    'cookie' => ['name' => 'i18nLocal'],
+                    'switchLangUrl' => '/lang',
+                ],
+                [
+                    'HTTP_HOST' => 'example.com',
+                    'REQUEST_URI' => '/lang',
+                ],
+                [
+                    'new' => 'it',
+                    'redirect' => 'home',
+                ],
+            ],
+            'valid redirect' => [
+                [
+                    'location' => 'https://example.com/credits',
+                    'status' => 302,
+                    'cookie' => 'it_IT',
+                ],
+                [
+                    'cookie' => [
+                        'name' => 'i18nLocal',
+                        'create' => true,
+                    ],
+                    'switchLangUrl' => '/lang',
+                ],
+                [
+                    'HTTP_HOST' => 'example.com',
+                    'REQUEST_URI' => '/lang',
+                ],
+                [
+                    'new' => 'it',
+                    'redirect' => 'https://example.com/credits',
+                ],
             ],
         ];
     }

--- a/tests/TestCase/Middleware/I18nMiddlewareTest.php
+++ b/tests/TestCase/Middleware/I18nMiddlewareTest.php
@@ -623,6 +623,28 @@ class I18nMiddlewareTest extends TestCase
                     'redirect' => 'https://example.com/credits',
                 ],
             ],
+            'valid redirect starting with "/"' => [
+                [
+                    'location' => '/credits',
+                    'status' => 302,
+                    'cookie' => 'it_IT',
+                ],
+                [
+                    'cookie' => [
+                        'name' => 'i18nLocal',
+                        'create' => true,
+                    ],
+                    'switchLangUrl' => '/lang',
+                ],
+                [
+                    'HTTP_HOST' => 'example.com',
+                    'REQUEST_URI' => '/lang',
+                ],
+                [
+                    'new' => 'it',
+                    'redirect' => '/credits',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR introduce an optional `redirect` query string used when switching language.

For example `https://example.com/lang?new=it&redirect=https%3A%2F%2Fexample.com%2Fhome` after changing language it redirects to `https://example.com/home`.