### PR TITLE
Locale path for plugin

### DIFF
--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -187,6 +187,14 @@ class GettextCommand extends Command
             $this->defaultDomain = $plugin;
             $localePaths = App::path('locales', $plugin);
             $this->localePath = (string)Hash::get($localePaths, '0');
+            if (empty($this->localePath)) {
+                foreach ($localesPaths as $path) {
+                    if (strpos($path, sprintf('%s%s%s', DS, $plugin, DS)) > 0) {
+                        $this->localePath = $path;
+                        break;
+                    }
+                }
+            }
 
             return;
         }

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -185,12 +185,8 @@ class GettextCommand extends Command
             ];
             $this->templatePaths = array_merge($paths, App::path(View::NAME_TEMPLATE, $plugin));
             $this->defaultDomain = $plugin;
-            foreach ($localesPaths as $path) {
-                if (strpos($path, sprintf('%s%s%s', DS, $plugin, DS)) > 0) {
-                    $this->localePath = $path;
-                    break;
-                }
-            }
+            $localePaths = App::path('locales', $plugin);
+            $this->localePath = (string)Hash::get($localePaths, '0');
 
             return;
         }

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -185,15 +185,13 @@ class GettextCommand extends Command
             ];
             $this->templatePaths = array_merge($paths, App::path(View::NAME_TEMPLATE, $plugin));
             $this->defaultDomain = $plugin;
+            $appLocalesPathsInPlugin = array_filter($localesPaths, function ($path) use ($plugin) {
+                return strpos($path, sprintf('%s%s%s', DS, $plugin, DS)) > 0;
+            });
             $localePaths = App::path('locales', $plugin);
             $this->localePath = (string)Hash::get($localePaths, '0');
             if (empty($this->localePath)) {
-                foreach ($localesPaths as $path) {
-                    if (strpos($path, sprintf('%s%s%s', DS, $plugin, DS)) > 0) {
-                        $this->localePath = $path;
-                        break;
-                    }
-                }
+                $this->localePath = (string)Hash::get($appLocalesPathsInPlugin, '0');
             }
 
             return;

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -185,14 +185,8 @@ class GettextCommand extends Command
             ];
             $this->templatePaths = array_merge($paths, App::path(View::NAME_TEMPLATE, $plugin));
             $this->defaultDomain = $plugin;
-            $appLocalesPathsInPlugin = array_filter($localesPaths, function ($path) use ($plugin) {
-                return strpos($path, sprintf('%s%s%s', DS, $plugin, DS)) > 0;
-            });
             $localePaths = App::path('locales', $plugin);
             $this->localePath = (string)Hash::get($localePaths, '0');
-            if (empty($this->localePath)) {
-                $this->localePath = (string)Hash::get($appLocalesPathsInPlugin, '0');
-            }
 
             return;
         }

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -73,9 +73,6 @@ class GettextCommandTest extends TestCase
      *
      * @return void
      * @covers ::execute()
-     * @covers ::getPoResult()
-     * @covers ::getTemplatePaths()
-     * @covers ::getLocalePath()
      */
     public function testExecute(): void
     {
@@ -100,9 +97,6 @@ class GettextCommandTest extends TestCase
      *
      * @return void
      * @covers ::execute()
-     * @covers ::getPoResult()
-     * @covers ::getTemplatePaths()
-     * @covers ::getLocalePath()
      */
     public function testUpdateWithCi(): void
     {
@@ -172,6 +166,8 @@ class GettextCommandTest extends TestCase
      * @return void
      * @dataProvider setupPathsProvider
      * @covers ::setupPaths()
+     * @covers ::getTemplatePaths()
+     * @covers ::getLocalePath()
      */
     public function testSetupPaths($appPath, $startPath, $pluginName, array $expectedTemplatePaths, string $expectedLocalePath): void
     {
@@ -471,6 +467,7 @@ msgstr \"\"
      * @return void
      * @dataProvider parseFileProvider
      * @covers ::parseFile()
+     * @covers ::getPoResult()
      */
     public function testParseFile(string $file, string $extension, array $expected): void
     {

--- a/tests/TestCase/Command/GettextCommandTest.php
+++ b/tests/TestCase/Command/GettextCommandTest.php
@@ -156,7 +156,7 @@ class GettextCommandTest extends TestCase
                     sprintf('%s/tests/test_app/plugins/Dummy/config', $base),
                     sprintf('%s/tests/test_app/plugins/Dummy/templates', $base),
                 ], // template paths
-                sprintf('%s/tests/test_app/plugins/Dummy/Locale', $base), // locale path
+                sprintf('%s/tests/test_app/plugins/Dummy/resources/locales', $base), // locale path
             ],
         ];
     }
@@ -175,7 +175,6 @@ class GettextCommandTest extends TestCase
      */
     public function testSetupPaths($appPath, $startPath, $pluginName, array $expectedTemplatePaths, string $expectedLocalePath): void
     {
-        $expectedPoName = 'default.po';
         $options = [];
         if (!empty($appPath)) {
             $options['app'] = sprintf('%s/%s', getcwd(), $appPath);
@@ -185,7 +184,6 @@ class GettextCommandTest extends TestCase
         }
         if (!empty($pluginName)) {
             $options['plugin'] = $pluginName;
-            $expectedPoName = sprintf('%s.po', $pluginName);
         }
         $args = new Arguments([], $options, []);
         $method = self::getMethod('setupPaths');


### PR DESCRIPTION
This fixes a bug on GettextCommand, when used for a plugin (i.e. `bin/cake gettext update -p Dummy`).

This patch makes the command find the Locale path in plugin configuration, with `App::path('locales', $plugin)`