### PR TITLE
ttag extract from resources path too

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,10 +27,10 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4","8.0","8.1"]'
-      bedita_version: '4.7.1'
+      bedita_version: '4.8.0'
 
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4","8.0","8.1"]'
-      bedita_version: '5.0.2'
+      bedita_version: '5.0.10'

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -516,6 +516,10 @@ class GettextCommand extends Command
 
             return;
         }
+        // Path to the resources directory defined in cakephp app config/paths.php
+        if (file_exists(RESOURCES)) {
+            $appDir = sprintf('%s %s', $appDir, RESOURCES);
+        }
 
         // do extract translation strings from js files using ttag
         $io->out('Extracting translation string from javascript files using ttag');

--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -517,7 +517,7 @@ class GettextCommand extends Command
             return;
         }
         // Path to the resources directory defined in cakephp app config/paths.php
-        if (file_exists(RESOURCES)) {
+        if (defined('RESOURCES') && file_exists(RESOURCES)) {
             $appDir = sprintf('%s %s', $appDir, RESOURCES);
         }
 


### PR DESCRIPTION
Cakephp app can have javascript files in `RESOURCES` path.

This makes `ttag` extract files from `RESOURCES` path too, if defined.

Bonus: update bedita_version in php workflow (`4.8.0` and `5.0.10`)