### PR TITLE
Fix /lang?new=:lang with no referer throws BadRequestException

### DIFF
--- a/src/Middleware/I18nMiddleware.php
+++ b/src/Middleware/I18nMiddleware.php
@@ -221,6 +221,7 @@ class I18nMiddleware implements MiddlewareInterface
 
     /**
      * Change lang and redirect to referer.
+     * If no referer found, redirect to "/".
      *
      * Require query string `new` and `redirect`
      *
@@ -247,9 +248,10 @@ class I18nMiddleware implements MiddlewareInterface
         }
 
         $redirect = (string)$request->getQuery('redirect', $request->referer(false));
-        if (strpos($redirect, '/') !== 0 && !Validation::url($redirect, true)) {
+        if (!empty($redirect) && strpos($redirect, '/') !== 0 && !Validation::url($redirect, true)) {
             throw new BadRequestException(__('"redirect" query string not valid'));
         }
+        $redirect = !empty($redirect) ? $redirect : '/';
 
         $this->updateSession($request, $locale);
 

--- a/tests/TestCase/Middleware/I18nMiddlewareTest.php
+++ b/tests/TestCase/Middleware/I18nMiddlewareTest.php
@@ -645,6 +645,27 @@ class I18nMiddlewareTest extends TestCase
                     'redirect' => '/credits',
                 ],
             ],
+            'no redirect, default /' => [
+                [
+                    'location' => 'https://example.com/credits',
+                    'status' => 302,
+                    'cookie' => 'it_IT',
+                ],
+                [
+                    'cookie' => [
+                        'name' => 'i18nLocal',
+                        'create' => true,
+                    ],
+                    'switchLangUrl' => '/lang',
+                ],
+                [
+                    'HTTP_HOST' => 'example.com',
+                    'REQUEST_URI' => '/lang',
+                ],
+                [
+                    'new' => 'it',
+                ],
+            ],
         ];
     }
 

--- a/tests/TestCase/Middleware/I18nMiddlewareTest.php
+++ b/tests/TestCase/Middleware/I18nMiddlewareTest.php
@@ -647,7 +647,7 @@ class I18nMiddlewareTest extends TestCase
             ],
             'no redirect, default /' => [
                 [
-                    'location' => 'https://example.com/credits',
+                    'location' => '/',
                     'status' => 302,
                     'cookie' => 'it_IT',
                 ],


### PR DESCRIPTION
This fixes an unexpected behaviour.

Actual Behaviour
=============

When opening an url `/lang?new=:lang`, with no referer, I18nMiddleware throws an exception `[Cake\Http\Exception\BadRequestException] "redirect" query string not valid`.

Expected Behaviour
===============

When opening an url `/lang?new=:lang`, with no referer, I18nMiddleware redirects to `/`.