### PR TITLE
Fix ttagExtract for a plugin

### DIFF
--- a/src/Command/GettextCommand.php
+++ b/src/Command/GettextCommand.php
@@ -517,7 +517,8 @@ class GettextCommand extends Command
             return;
         }
         // Path to the resources directory defined in cakephp app config/paths.php
-        if (defined('RESOURCES') && file_exists(RESOURCES)) {
+        // Do not add RESOURCES path when it's a plugin
+        if (empty($plugin) && defined('RESOURCES') && file_exists(RESOURCES)) {
             $appDir = sprintf('%s %s', $appDir, RESOURCES);
         }
 


### PR DESCRIPTION
This provides a fix on `bin/cake gettext update -p PluginName`: app RESOURCES is ignored when it's a plugin, otherwise a lot of app's translations will be added to plugin's po and pot files.