### PR TITLE
Upgrade cakephp 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=7.4",
         "ext-intl": "*",
-        "cakephp/cakephp": "^4.2.2",
+        "cakephp/cakephp": "^4.4",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=7.4",
         "ext-intl": "*",
-        "cakephp/cakephp": "^4.4",
+        "cakephp/cakephp": "^4.4.0",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",


### PR DESCRIPTION
This updates composer dependency for cakephp to version 4.4

Note: `cd <cakephp-upgrade-path>; bin/cake upgrade rector --rules cakephp44 <i18n-path>/src`, no change applied.