### PR TITLE
Translator interface

### DIFF
--- a/src/Core/TranslatorInterface.php
+++ b/src/Core/TranslatorInterface.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\I18n\Core;
+
+/**
+ * Translator interface
+ *
+ * @codeCoverageIgnore
+ */
+interface TranslatorInterface
+{
+    /**
+     * Setup translator engine.
+     *
+     * @param array $options The options
+     * @return void
+     */
+    public function setup(array $options = []): void;
+
+    /**
+     * Translate a text $text from language source $from to language target $to
+     *
+     * @param array $text The texts to translate
+     * @param string $from The source language
+     * @param string $to The target language
+     * @return string The translation in json format as string, i.e.
+     * {
+     *     "translation": [
+     *         "<translation of first text>",
+     *         "<translation of second text>",
+     *         [...]
+     *         "<translation of last text>"
+     *     ]
+     * }
+     */
+    public function translate(array $text, string $from, string $to): string;
+}

--- a/tests/TestCase/View/Helper/I18nHelperTest.php
+++ b/tests/TestCase/View/Helper/I18nHelperTest.php
@@ -474,7 +474,7 @@ class I18nHelperTest extends TestCase
                 ],
             ],
             'meta' => [
-                '<link href="http://localhost/en/help" rel="alternate" hreflang="en"/><link href="http://localhost/it/help" rel="alternate" hreflang="it"/>',
+                '<link href="http://localhost/en/help" rel="alternate" hreflang="en"><link href="http://localhost/it/help" rel="alternate" hreflang="it">',
                 [
                     'REQUEST_URI' => '/en/help',
                     'PHP_SELF' => '/',


### PR DESCRIPTION
This adds a `TranslatorInterface`.

The `TranslatorInterface` provides the basic interface for translator implementations (i.e. aws, deepl, google, microsoft implementations).

Spolier alert: coming soon new bedita repositories for implementations:

 - `bedita/i18n-aws`
 - `bedita/i18n-deepl`
 - `bedita/i18n-google`
 - `bedita/i18n-microsoft`

Bonus: fix `testMetaHreflang`